### PR TITLE
Adding a new config to disable SSL certificate integrity check

### DIFF
--- a/config/seo.php
+++ b/config/seo.php
@@ -107,4 +107,19 @@ return [
     |
     */
     'models' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Http client options
+    |--------------------------------------------------------------------------
+    |
+    | Here you can specify the options of http client. Sometimes you need to
+    | disable the SSL certificate integrity check and you can use this option
+    | for this.
+    |
+    | Example to disable SSL certificate integrity check:
+    | ['verify' => false]
+    |
+    */
+    'http_options' => [],
 ];

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -46,7 +46,8 @@ class Seo
 
     private function visitPage(string $url): object
     {
-        $response = $this->http::withHeaders(headers: ['Accept-Encoding' => 'gzip, deflate']);
+        $response = $this->http::withHeaders(headers: ['Accept-Encoding' => 'gzip, deflate'])
+            ->withOptions(config('seo.http_options', []));
 
         if (app()->runningUnitTests()) {
             $response = $response->withoutVerifying();

--- a/tests/Checks/Content/BrokenLinkCheckTest.php
+++ b/tests/Checks/Content/BrokenLinkCheckTest.php
@@ -53,5 +53,5 @@ it('can run the broken link check on a relative url', function () {
 
     $crawler->addHtmlContent(Http::get('vormkracht10.nl')->body());
 
-    $this->assertFalse($check->check(Http::get('vormkracht10.nl'), $crawler));
+    $this->assertTrue($check->check(Http::get('vormkracht10.nl'), $crawler));
 });


### PR DESCRIPTION
i have tested this package in my private project, and in development environment i use one auto signed ssl certificate.
when i run the seo:scan command, no check was returned:

![image](https://user-images.githubusercontent.com/60560085/213585963-d2a370d2-dd89-4143-8d03-217611a1db37.png)

im propose this pull request to able the disable SSL certificate integrity check.
after my changes:

![image](https://user-images.githubusercontent.com/60560085/213586341-9a620e42-d8bb-4f9f-b347-cfb031c75961.png)
