### PR TITLE
[Fix] Handle request exceptions

### DIFF
--- a/src/Seo.php
+++ b/src/Seo.php
@@ -41,7 +41,7 @@ class Seo
                 $javascriptResponse = $this->visitPageUsingJavascript(url: $url);
             }
         } catch (\Exception $e) {
-            return (new SeoScore)($this->successful, $this->failed);
+            throw new \Exception("Could not visit url `{$url}`: {$e->getMessage()}");
         }
 
         $this->runChecks(response: $response, javascriptResponse: $javascriptResponse ?? null);

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -62,11 +62,10 @@ class Seo
         $headers = (array) config('seo.http.headers', []);
         $options = (array) config('seo.http.options', []);
 
-        $options = array_merge($options, [
-            'decode_content' => false,
-        ]);
-
-        $response = $this->http::withOptions($options)
+        $response = $this->http::withOptions([
+                'decode_content' => false,
+                ...$options
+            ])
             ->withHeaders([
                 'Accept-Encoding' => 'gzip, deflate',
                 ...$headers,

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -63,9 +63,9 @@ class Seo
         $options = (array) config('seo.http.options', []);
 
         $response = $this->http::withOptions([
-                'decode_content' => false,
-                ...$options
-            ])
+            'decode_content' => false,
+            ...$options,
+        ])
             ->withHeaders([
                 'Accept-Encoding' => 'gzip, deflate',
                 ...$headers,

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -65,6 +65,7 @@ class Seo
         $response = $this->http::withOptions($options)
             ->withHeaders([
                 'Accept-Encoding' => 'gzip, deflate',
+                'decode_content' => false,
                 ...$headers,
             ]);
 

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -62,10 +62,13 @@ class Seo
         $headers = (array) config('seo.http.headers', []);
         $options = (array) config('seo.http.options', []);
 
+        $options = array_merge($options, [
+            'decode_content' => false,
+        ]);
+
         $response = $this->http::withOptions($options)
             ->withHeaders([
                 'Accept-Encoding' => 'gzip, deflate',
-                'decode_content' => false,
                 ...$headers,
             ]);
 


### PR DESCRIPTION
This PR makes sure an error gets thrown with the error message when a request fails. It also fixes the following error: 

> Unrecognized content encoding type. libcurl understands deflate, gzip content encodings. #2146
