### PR TITLE
[Bug fix] Ignoring ssl integrity check for assets files

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -71,7 +71,14 @@ if (! function_exists('getRemoteFileSize')) {
             }
 
             if (! isset($contentLength)) {
-                $contentLength = strlen(file_get_contents($url));
+                $context = stream_context_create([
+                    'ssl' => [
+                        'verify_peer' => false,
+                        'verify_peer_name' => false
+                    ],
+                ]);
+
+                $contentLength = strlen(file_get_contents($url, false, $context));
             }
 
             return $contentLength;

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -71,14 +71,12 @@ if (! function_exists('getRemoteFileSize')) {
             }
 
             if (! isset($contentLength)) {
-                $context = stream_context_create([
-                    'ssl' => [
-                        'verify_peer' => false,
-                        'verify_peer_name' => false
-                    ],
-                ]);
+                $options = (array) config('seo.http.options', []);
+                $context = isset($options['verify']) && !$options['verify']
+                    ? $context = ['ssl' => ['verify_peer' => false, 'verify_peer_name' => false]]
+                    : [];
 
-                $contentLength = strlen(file_get_contents($url, false, $context));
+                $contentLength = strlen(file_get_contents($url, false, stream_context_create($context)));
             }
 
             return $contentLength;


### PR DESCRIPTION
Hey @Baspa 👋 long time no see you, im upgrading some package versions in my project and when i've tested the new versions of laravel-seo-scanner im receiving this error:

![image](https://github.com/user-attachments/assets/f9411f63-7f14-485c-b3eb-8193f8b0574d)

After these changes:

![image](https://github.com/user-attachments/assets/2252ab02-bf8e-4178-88b8-450a38fc30b3)


This PR aims to solve this problem, can u check if its relevant for the package?
