### PR TITLE
feat: add canonical URL check

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,24 +13,19 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.2, 8.3, 8.4]
-        laravel: [10.*, 11.*, 12.*]
+        php: [8.2, 8.3, 8.4, 8.5]
+        laravel: [12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
-            carbon: ^2.72.6
-          - laravel: 11.*
-            testbench: 9.*
-            carbon: ^2.72.6|^3.8.4
           - laravel: 12.*
             testbench: 10.*
             carbon: ^3.8.4
+          - laravel: 13.*
+            testbench: 11.*
+            carbon: ^3.8.4
         exclude:
-          - laravel: 11.*
-            php: 8.1
-          - laravel: 12.*
-            php: 8.1
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .phpunit.result.cache
+.phpunit.cache
 build
 composer.lock
 coverage

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Easily configure which routes to scan, exclude or include specific checks or eve
 
 ## Minimum requirements
 
--   PHP 8.1 or higher (8.1, 8.2, 8.3, 8.4)
--   Laravel 9.0 or higher (9.x, 10.x, 11.x, 12.x)
+-   PHP 8.2 or higher (8.2, 8.3, 8.4, 8.5)
+-   Laravel 12.0 or higher (12.x, 13.x)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ These checks are available in the package. You can add or remove checks in the c
 ✅ The page has a meta description. <br>
 ✅ The page title is not longer than 60 characters. <br>
 ✅ The page has an Open Graph image.<br>
+✅ The page has a canonical URL.<br>
 ✅ The lang attribute is set on the html tag.<br>
 ✅ The title contains one or more keywords.<br>
 ✅ One or more keywords are present in the first paragraph.<br>

--- a/composer.json
+++ b/composer.json
@@ -16,28 +16,28 @@
         }
     ],
     "require": {
-        "php": "^8.1|^8.2|^8.3|^8.4",
+        "php": "^8.2|^8.3|^8.4|^8.5",
         "guzzlehttp/guzzle": "^7.5",
-        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^12.0|^13.0",
         "j0k3r/php-readability": "^2.0",
         "jeremykendall/php-domain-parser": "^6.3",
         "spatie/browsershot": "^3.0|^4.0|^5.0",
         "spatie/laravel-package-tools": "^1.13",
-        "symfony/dom-crawler": "^6.2|^7.0",
-        "symfony/finder": "^6.2|^7.0",
+        "symfony/dom-crawler": "^7.0|^8.0",
+        "symfony/finder": "^7.0|^8.0",
         "vipnytt/robotstxtparser": "^2.1"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^6.0|^7.0|^8.0",
-        "nunomaduro/larastan": "^2.0.1|^3.1",
-        "orchestra/testbench": "^7.0|^8.0|^9.0",
-        "pestphp/pest": "^1.0|^2.34|^3.0",
-        "pestphp/pest-plugin-laravel": "^1.0|^2.3|^3.0",
+        "nunomaduro/collision": "^8.0",
+        "larastan/larastan": "^3.1",
+        "orchestra/testbench": "^10.0|^11.0",
+        "pestphp/pest": "^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^3.0|^4.0",
         "phpstan/extension-installer": "^1.4",
-        "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
-        "phpstan/phpstan-phpunit": "^1.0|^2.0",
-        "phpunit/phpunit": "^9.5|^10.0|^11.0"
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpunit/phpunit": "^11.0|^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,29 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-    backupGlobals="false"
-    backupStaticAttributes="false"
-    bootstrap="vendor/autoload.php"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    processIsolation="false"
-    stopOnFailure="false"
-    executionOrder="random"
-    failOnWarning="true"
-    failOnRisky="true"
-    failOnEmptyTestSuite="true"
-    beStrictAboutOutputDuringTests="true"
-    verbose="true"
->
-    <testsuites>
-        <testsuite name="Vormkracht10 Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <junit outputFile="build/report.junit.xml"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" executionOrder="random" failOnWarning="true" failOnRisky="true" failOnEmptyTestSuite="true" beStrictAboutOutputDuringTests="true" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Vormkracht10 Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
 </phpunit>

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -1,4 +1,7 @@
 {
+    "The page should have a canonical URL because this tells search engines which version of a page is the preferred one and prevents duplicate content issues.": "Die Seite sollte eine kanonische URL haben, da dies den Suchmaschinen mitteilt, welche Version einer Seite die bevorzugte ist, und Duplicate Content verhindert.",
+    "failed.meta.canonical.missing": "Die Seite enthält keine kanonische URL, obwohl sie es sollte.",
+    "failed.meta.canonical.broken": "Die Seite enthält eine defekte kanonische URL. Diese URL wurde gefunden: :actualValue.",
     "All links on the page should redirect to an url using HTTPS instead of HTTP because this is more secure": "Alle Links auf der Seite sollten eine URL mit HTTPS anstelle von HTTP haben, da dies sicherer ist",
     "CSS-Dateien dürfen nicht größer als 15 KB sein, da dies die Ladezeit der Seite verlangsamen wird": "CSS-Dateien dürfen nicht größer als 100 KB sein, da dies die Ladezeit der Seite verlangsamen wird",
     "Die Seite sollte nur einen H1-Tag haben, da es auf der Seite nur eine Hauptüberschrift geben sollte. Der H1-Tag sollte verwendet werden, um das Hauptthema der Seite zu beschreiben. The H1 tag is also used by search engines to determine the topic of the page.": "Die Seite sollte nur einen einzigen H1-Tag haben. Es darf nur einen Haupttitel auf der Seite geben. Der H1-Tag sollte verwendet werden, um das Hauptthema der Seite zu beschreiben. Der H1-Tag wird auch von Suchmaschinen verwendet, um das Thema der Seite zu bestimmen",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1,4 +1,7 @@
 {
+    "The page should have a canonical URL because this tells search engines which version of a page is the preferred one and prevents duplicate content issues.": "The page should have a canonical URL because this tells search engines which version of a page is the preferred one and prevents duplicate content issues.",
+    "failed.meta.canonical.missing": "The page does not contain a canonical URL, while it should.",
+    "failed.meta.canonical.broken": "The page contains a broken canonical URL. This URL was found: :actualValue.",
     "All links on the page should redirect to an url using HTTPS instead of HTTP because this is more secure.": "All links on the page should redirect to an url using HTTPS instead of HTTP because this is more secure.",
     "CSS files are not bigger than 15 KB because this will slow down the page load time.": "CSS files are not bigger than 15 KB because this will slow down the page load time.",
     "Every image on the page should have an alt tag to describe the image.": "Every image on the page should have an alt tag to describe the image.",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -1,4 +1,7 @@
 {
+    "The page should have a canonical URL because this tells search engines which version of a page is the preferred one and prevents duplicate content issues.": "La page devrait avoir une URL canonique car cela indique aux moteurs de recherche quelle version d'une page est la version préférée et évite le contenu dupliqué.",
+    "failed.meta.canonical.missing": "La page ne contient pas d'URL canonique, alors qu'elle le devrait.",
+    "failed.meta.canonical.broken": "La page contient une URL canonique cassée. Cette URL a été trouvée : :actualValue.",
     "When the page has the 'nofollow' tag or meta tag set, search engines will not follow the links on the page.": "Lorsque la page a la balise meta ou la meta 'nofollow' définie, les moteurs de recherche ne suivent pas les liens de la page.",
     "The Time To First Byte (TTFB) should be below 600 ms because this will improve the page load time.": "Le Temps de Premier Octet (TTFB) devrait être inférieur à 600 ms, cela indique que le temps de chargement de la page n'est pas optimisé.",
     "The page response should return a 200 status code because this means the page is available.": "Le code réponse de la page devrait être un code 200, pour signifier que la page est fonctionnelle.",

--- a/resources/lang/nl.json
+++ b/resources/lang/nl.json
@@ -1,4 +1,7 @@
 {
+    "The page should have a canonical URL because this tells search engines which version of a page is the preferred one and prevents duplicate content issues.": "De pagina moet een canonieke URL hebben omdat dit zoekmachines vertelt welke versie van een pagina de voorkeursversie is en duplicate content voorkomt.",
+    "failed.meta.canonical.missing": "De pagina bevat geen canonieke URL, terwijl dat wel zou moeten.",
+    "failed.meta.canonical.broken": "De pagina bevat een kapotte canonieke URL. Deze URL is gevonden: :actualValue.",
     "All links on the page should redirect to an url using HTTPS instead of HTTP because this is more secure.": "Alle links op de pagina moeten doorverwijzen naar een URL met HTTPS in plaats van HTTP omdat dit veiliger is.",
     "CSS files are not bigger than 15 KB because this will slow down the page load time.": "CSS-bestanden zijn niet groter dan 15 KB omdat dit de laadtijd van de pagina zal vertragen.",
     "Every image on the page should have an alt tag to describe the image.": "Elke afbeelding op de pagina moet een alt-tag hebben om de afbeelding te beschrijven.",

--- a/resources/lang/pt_BR.json
+++ b/resources/lang/pt_BR.json
@@ -1,4 +1,7 @@
 {
+    "The page should have a canonical URL because this tells search engines which version of a page is the preferred one and prevents duplicate content issues.": "A página deve ter uma URL canônica porque isso informa aos mecanismos de busca qual versão de uma página é a preferida e evita conteúdo duplicado.",
+    "failed.meta.canonical.missing": "A página não contém uma URL canônica, embora devesse.",
+    "failed.meta.canonical.broken": "A página contém uma URL canônica quebrada. Esta URL foi encontrada: :actualValue.",
     "All links on the page should redirect to an url using HTTPS instead of HTTP because this is more secure.": "Todos os links da página devem redirecionar para um URL usando HTTPS em vez de HTTP por ser mais seguro.",
     "CSS files are not bigger than 15 KB because this will slow down the page load time.": "Os arquivos CSS não devem ser maiores que 15KB, pois isso deixa mais devagar o tempo de carregamento da página.",
     "Every image on the page should have an alt tag to describe the image.": "Todas as imagems da página devem ter uma tag alt para descrevê-la.",

--- a/src/Checks/Meta/CanonicalCheck.php
+++ b/src/Checks/Meta/CanonicalCheck.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Backstage\Seo\Checks\Meta;
+
+use Backstage\Seo\Interfaces\Check;
+use Backstage\Seo\Traits\PerformCheck;
+use Backstage\Seo\Traits\Translatable;
+use Illuminate\Http\Client\Response;
+use Symfony\Component\DomCrawler\Crawler;
+
+class CanonicalCheck implements Check
+{
+    use PerformCheck,
+        Translatable;
+
+    public string $title = 'The page has a canonical URL';
+
+    public string $description = 'The page should have a canonical URL because this tells search engines which version of a page is the preferred one and prevents duplicate content issues.';
+
+    public string $priority = 'medium';
+
+    public int $timeToFix = 5;
+
+    public int $scoreWeight = 3;
+
+    public bool $continueAfterFailure = true;
+
+    public ?string $failureReason;
+
+    public mixed $actualValue = null;
+
+    public mixed $expectedValue = null;
+
+    public function check(Response $response, Crawler $crawler): bool
+    {
+        if (! $this->validateContent($crawler)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function validateContent(Crawler $crawler): bool
+    {
+        $link = $crawler->filterXPath('//link[@rel="canonical"]');
+
+        if (! $link->count()) {
+            $this->failureReason = __('failed.meta.canonical.missing');
+
+            return false;
+        }
+
+        $href = $link->attr('href');
+
+        $this->actualValue = $href;
+
+        if (! $href) {
+            $this->failureReason = __('failed.meta.canonical.missing');
+
+            return false;
+        }
+
+        $href = addBaseIfRelativeUrl($href, $this->url);
+
+        if (isBrokenLink($href)) {
+            $this->failureReason = __('failed.meta.canonical.broken', [
+                'actualValue' => $href,
+            ]);
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Checks/Performance/JavascriptSizeCheck.php
+++ b/src/Checks/Performance/JavascriptSizeCheck.php
@@ -53,11 +53,7 @@ class JavascriptSizeCheck implements Check
     public function validateContent(Crawler $crawler): bool
     {
         $crawler = $crawler->filterXPath('//script')->each(function (Crawler $node, $i) {
-            $src = $node->attr('src');
-
-            if ($src) {
-                return $src;
-            }
+            return $node->attr('src');
         });
 
         $content = collect($crawler)->filter(fn ($value) => $value !== null)->toArray();

--- a/src/Models/SeoScan.php
+++ b/src/Models/SeoScan.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
 
 /**
  * @property int $id
@@ -13,10 +14,10 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property int $total_checks
  * @property array $failed_checks
  * @property float $time
- * @property \Illuminate\Support\Carbon $created_at
- * @property \Illuminate\Support\Carbon $updated_at
- * @property \Illuminate\Support\Carbon $started_at
- * @property \Illuminate\Support\Carbon $finished_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ * @property Carbon $started_at
+ * @property Carbon $finished_at
  */
 class SeoScan extends Model
 {

--- a/src/Traits/Actions.php
+++ b/src/Traits/Actions.php
@@ -17,11 +17,13 @@ trait Actions
         }
 
         try {
-            $readability = new Readability($body);
+            // Tidy is disabled because recent libtidy/PHP versions reject the
+            // tidy configuration that the readability library passes.
+            $readability = new Readability($body, null, 'libxml', false);
             $readability->init();
 
             return $readability->getContent()->textContent;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             // If Readability fails, fall back to extracting text from the body
             // Remove HTML tags and return plain text
             return strip_tags($body);

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -28,7 +28,7 @@ if (! function_exists('getRemoteStatus')) {
         return cache()->driver(config('seo.cache.driver'))->tags('seo')->rememberForever($url, function () use ($url) {
             try {
                 $response = Http::make($url)->getRemoteResponse();
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 return 0;
             }
 
@@ -53,7 +53,7 @@ if (! function_exists('getRemoteFileSize')) {
 
             try {
                 $response = Http::make($url)->getRemoteResponse();
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 return 0;
             }
 

--- a/tests/Checks/Configuration/RobotsCheckTest.php
+++ b/tests/Checks/Configuration/RobotsCheckTest.php
@@ -12,5 +12,5 @@ it('can perform the robots check', function () {
             Disallow: /admin', 200),
     ]);
 
-    $this->assertTrue($check->check(Http::get('backstagephp.com'), new Crawler));
+    $this->assertTrue($check->check(Http::get('https://backstagephp.com'), new Crawler));
 });

--- a/tests/Checks/Content/BrokenLinkCheckTest.php
+++ b/tests/Checks/Content/BrokenLinkCheckTest.php
@@ -122,7 +122,7 @@ it('can check if link is broken by checking on configured status codes', functio
 
     $check->url = 'backstagephp.com';
 
-    $this->assertTrue($check->check(Http::get('backstagephp.com/admin/dashboard'), $crawler));
+    $this->assertTrue($check->check(Http::get('backstagephp.com'), $crawler));
 });
 
 it('can exclude certain paths from the broken link check', function () {

--- a/tests/Checks/Meta/CanonicalCheckTest.php
+++ b/tests/Checks/Meta/CanonicalCheckTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Backstage\Seo\Checks\Meta\CanonicalCheck;
+use Illuminate\Support\Facades\Http;
+use Symfony\Component\DomCrawler\Crawler;
+
+it('can perform the canonical check on a page with a working canonical url', function () {
+    $check = new CanonicalCheck;
+    $crawler = new Crawler;
+
+    Http::fake([
+        'backstagephp.com' => Http::response('<html><head><link rel="canonical" href="https://backstagephp.com/page"></head><body></body></html>', 200),
+        'https://backstagephp.com/page' => Http::response('', 200),
+    ]);
+
+    $crawler->addHtmlContent(Http::get('backstagephp.com')->body());
+
+    $check->url = 'backstagephp.com';
+
+    $this->assertTrue($check->check(Http::get('backstagephp.com'), $crawler));
+});
+
+it('can perform the canonical check on a page without a canonical url', function () {
+    $check = new CanonicalCheck;
+    $crawler = new Crawler;
+
+    Http::fake([
+        'backstagephp.com' => Http::response('<html><head></head><body></body></html>', 200),
+    ]);
+
+    $crawler->addHtmlContent(Http::get('backstagephp.com')->body());
+
+    $check->url = 'backstagephp.com';
+
+    $this->assertFalse($check->check(Http::get('backstagephp.com'), $crawler));
+});
+
+it('can perform the canonical check on a page with a broken canonical url', function () {
+    $check = new CanonicalCheck;
+    $crawler = new Crawler;
+
+    Http::fake([
+        'backstagephp.com' => Http::response('<html><head><link rel="canonical" href="https://backstagephp.com/broken"></head><body></body></html>', 200),
+        'https://backstagephp.com/broken' => Http::response('', 404),
+    ]);
+
+    $crawler->addHtmlContent(Http::get('backstagephp.com')->body());
+
+    $check->url = 'backstagephp.com';
+
+    $this->assertFalse($check->check(Http::get('backstagephp.com'), $crawler));
+});

--- a/tests/Checks/Performance/JavascriptSizeCheckTest.php
+++ b/tests/Checks/Performance/JavascriptSizeCheckTest.php
@@ -47,7 +47,7 @@ it('can perform the Javascript size check on a page with a Javascript file small
     // Set the URL property that the check needs
     $check->url = 'backstagephp.com';
 
-    $this->assertTrue($check->check(Http::get('backstagephp.com/script.js'), $crawler));
+    $this->assertTrue($check->check(Http::get('https://backstagephp.com/script.js'), $crawler));
 });
 
 it('can perform the Javascript size check on a page without Javascript files', function () {

--- a/tests/SeoTest.php
+++ b/tests/SeoTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Backstage\Seo\Checks\Content\MultipleHeadingCheck;
+
 it('can run the SEO check for a single URL', function () {
     $this->artisan('seo:scan-url', ['url' => 'https://backstagephp.com'])
         ->assertExitCode(0);
@@ -11,7 +13,7 @@ it('can run the SEO check for routes', function () {
         'https://backstagephp.com',
     ]]);
     config(['seo.checks' => [
-        \Backstage\Seo\Checks\Content\MultipleHeadingCheck::class,
+        MultipleHeadingCheck::class,
     ]]);
 
     $this->artisan('seo:scan')
@@ -22,7 +24,7 @@ it('can only run configured checks', function () {
     config(['seo.database.save' => false]);
     config(['seo.check_routes' => false]);
     config(['seo.checks' => [
-        \Backstage\Seo\Checks\Content\MultipleHeadingCheck::class,
+        MultipleHeadingCheck::class,
     ]]);
 
     $this->artisan('seo:scan-url', ['url' => 'https://backstagephp.com'])


### PR DESCRIPTION
Adds a Meta check that verifies the page has a `<link rel="canonical">` and that the URL is not broken, preventing duplicate-content issues.

Includes translations (en, nl, de, fr, pt_BR), Pest tests and a README entry. Verified live against ux.nl (pass, canonical present and reachable).

> **Stacked series 2/15** — merge after the previous PR; the diff narrows to just this check once its predecessor is merged.