### PR TITLE
feat: add llms.txt check

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ These checks are available in the package. You can add or remove checks in the c
 ✅ The page does not have 'nofollow' set. <br>
 ✅ Robots.txt allows indexing. <br>
 
+### AI
+
+✅ The site provides an llms.txt file. <br>
+
 ### Content
 
 ✅ The page has an H1 tag and if it is used only once per page. <br>

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -1,4 +1,6 @@
 {
+    "The site should provide an llms.txt file because it gives large language models a curated, Markdown overview of the site, which improves how AI tools understand and cite the content.": "Die Website sollte eine llms.txt-Datei bereitstellen, da sie großen Sprachmodellen einen kuratierten Markdown-Überblick über die Website bietet, was verbessert, wie KI-Tools die Inhalte verstehen und zitieren.",
+    "failed.ai.llms_txt.missing": "Wir konnten unter :actualValue keine llms.txt-Datei für diese Website finden, obwohl sie für die Sichtbarkeit bei KI und LLMs empfohlen wird.",
     "The page should have a canonical URL because this tells search engines which version of a page is the preferred one and prevents duplicate content issues.": "Die Seite sollte eine kanonische URL haben, da dies den Suchmaschinen mitteilt, welche Version einer Seite die bevorzugte ist, und Duplicate Content verhindert.",
     "failed.meta.canonical.missing": "Die Seite enthält keine kanonische URL, obwohl sie es sollte.",
     "failed.meta.canonical.broken": "Die Seite enthält eine defekte kanonische URL. Diese URL wurde gefunden: :actualValue.",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1,4 +1,6 @@
 {
+    "The site should provide an llms.txt file because it gives large language models a curated, Markdown overview of the site, which improves how AI tools understand and cite the content.": "The site should provide an llms.txt file because it gives large language models a curated, Markdown overview of the site, which improves how AI tools understand and cite the content.",
+    "failed.ai.llms_txt.missing": "We could not find an llms.txt file for this site at :actualValue, while one is recommended for AI and LLM visibility.",
     "The page should have a canonical URL because this tells search engines which version of a page is the preferred one and prevents duplicate content issues.": "The page should have a canonical URL because this tells search engines which version of a page is the preferred one and prevents duplicate content issues.",
     "failed.meta.canonical.missing": "The page does not contain a canonical URL, while it should.",
     "failed.meta.canonical.broken": "The page contains a broken canonical URL. This URL was found: :actualValue.",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -1,4 +1,6 @@
 {
+    "The site should provide an llms.txt file because it gives large language models a curated, Markdown overview of the site, which improves how AI tools understand and cite the content.": "Le site devrait fournir un fichier llms.txt, car il offre aux grands modèles de langage un aperçu Markdown structuré du site, ce qui améliore la façon dont les outils d'IA comprennent et citent le contenu.",
+    "failed.ai.llms_txt.missing": "Nous n'avons pas trouvé de fichier llms.txt pour ce site à l'adresse :actualValue, alors qu'il est recommandé pour la visibilité auprès des IA et des LLM.",
     "The page should have a canonical URL because this tells search engines which version of a page is the preferred one and prevents duplicate content issues.": "La page devrait avoir une URL canonique car cela indique aux moteurs de recherche quelle version d'une page est la version préférée et évite le contenu dupliqué.",
     "failed.meta.canonical.missing": "La page ne contient pas d'URL canonique, alors qu'elle le devrait.",
     "failed.meta.canonical.broken": "La page contient une URL canonique cassée. Cette URL a été trouvée : :actualValue.",

--- a/resources/lang/nl.json
+++ b/resources/lang/nl.json
@@ -1,4 +1,6 @@
 {
+    "The site should provide an llms.txt file because it gives large language models a curated, Markdown overview of the site, which improves how AI tools understand and cite the content.": "De site zou een llms.txt-bestand moeten aanbieden, omdat dit large language models een samengesteld Markdown-overzicht van de site geeft, wat verbetert hoe AI-tools de inhoud begrijpen en citeren.",
+    "failed.ai.llms_txt.missing": "We konden geen llms.txt-bestand voor deze site vinden op :actualValue, terwijl dit wordt aanbevolen voor AI- en LLM-zichtbaarheid.",
     "The page should have a canonical URL because this tells search engines which version of a page is the preferred one and prevents duplicate content issues.": "De pagina moet een canonieke URL hebben omdat dit zoekmachines vertelt welke versie van een pagina de voorkeursversie is en duplicate content voorkomt.",
     "failed.meta.canonical.missing": "De pagina bevat geen canonieke URL, terwijl dat wel zou moeten.",
     "failed.meta.canonical.broken": "De pagina bevat een kapotte canonieke URL. Deze URL is gevonden: :actualValue.",

--- a/resources/lang/pt_BR.json
+++ b/resources/lang/pt_BR.json
@@ -1,4 +1,6 @@
 {
+    "The site should provide an llms.txt file because it gives large language models a curated, Markdown overview of the site, which improves how AI tools understand and cite the content.": "O site deve fornecer um arquivo llms.txt porque ele oferece aos grandes modelos de linguagem uma visão geral curada em Markdown do site, o que melhora como as ferramentas de IA entendem e citam o conteúdo.",
+    "failed.ai.llms_txt.missing": "Não encontramos um arquivo llms.txt para este site em :actualValue, embora seja recomendado para a visibilidade em IA e LLMs.",
     "The page should have a canonical URL because this tells search engines which version of a page is the preferred one and prevents duplicate content issues.": "A página deve ter uma URL canônica porque isso informa aos mecanismos de busca qual versão de uma página é a preferida e evita conteúdo duplicado.",
     "failed.meta.canonical.missing": "A página não contém uma URL canônica, embora devesse.",
     "failed.meta.canonical.broken": "A página contém uma URL canônica quebrada. Esta URL foi encontrada: :actualValue.",

--- a/src/Checks/Ai/LlmsTxtCheck.php
+++ b/src/Checks/Ai/LlmsTxtCheck.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Backstage\Seo\Checks\Ai;
+
+use Backstage\Seo\Interfaces\Check;
+use Backstage\Seo\Traits\PerformCheck;
+use Backstage\Seo\Traits\Translatable;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use Symfony\Component\DomCrawler\Crawler;
+
+class LlmsTxtCheck implements Check
+{
+    use PerformCheck,
+        Translatable;
+
+    public string $title = 'The site provides an llms.txt file';
+
+    public string $description = 'The site should provide an llms.txt file because it gives large language models a curated, Markdown overview of the site, which improves how AI tools understand and cite the content.';
+
+    public string $priority = 'low';
+
+    public int $timeToFix = 30;
+
+    public int $scoreWeight = 1;
+
+    public bool $continueAfterFailure = true;
+
+    public ?string $failureReason;
+
+    public mixed $actualValue = null;
+
+    public mixed $expectedValue = null;
+
+    public function check(Response $response, Crawler $crawler): bool
+    {
+        $base = $this->baseUrl($response);
+
+        if (! $base) {
+            $this->failureReason = __('failed.ai.llms_txt.missing', ['actualValue' => '-']);
+
+            return false;
+        }
+
+        $url = $base.'/llms.txt';
+
+        $this->actualValue = $url;
+
+        $llms = Http::get($url);
+
+        if ($llms->successful() && trim((string) $llms->body()) !== '') {
+            return true;
+        }
+
+        $this->failureReason = __('failed.ai.llms_txt.missing', ['actualValue' => $url]);
+
+        return false;
+    }
+
+    protected function baseUrl(Response $response): ?string
+    {
+        $url = $this->url ?? ($response->transferStats?->getHandlerStats()['url'] ?? null);
+
+        if (! $url) {
+            return null;
+        }
+
+        if (! preg_match('#^https?://#i', $url)) {
+            $url = 'https://'.$url;
+        }
+
+        $parts = parse_url($url);
+
+        if (empty($parts['host'])) {
+            return null;
+        }
+
+        $scheme = $parts['scheme'] ?? 'https';
+
+        return $scheme.'://'.$parts['host'].(isset($parts['port']) ? ':'.$parts['port'] : '');
+    }
+}

--- a/tests/Checks/Ai/LlmsTxtCheckTest.php
+++ b/tests/Checks/Ai/LlmsTxtCheckTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use Backstage\Seo\Checks\Ai\LlmsTxtCheck;
+use Illuminate\Support\Facades\Http;
+use Symfony\Component\DomCrawler\Crawler;
+
+it('passes when the site provides a non-empty llms.txt file', function () {
+    $check = new LlmsTxtCheck;
+    $check->url = 'https://backstagephp.com';
+
+    Http::fake([
+        'backstagephp.com/llms.txt' => Http::response("# Backstage\n\nA Laravel package.", 200),
+        '*' => Http::response('<html></html>', 200),
+    ]);
+
+    expect($check->check(Http::get('https://backstagephp.com'), new Crawler))->toBeTrue();
+});
+
+it('fails when the llms.txt file is missing', function () {
+    $check = new LlmsTxtCheck;
+    $check->url = 'https://backstagephp.com';
+
+    Http::fake([
+        'backstagephp.com/llms.txt' => Http::response('Not found', 404),
+        '*' => Http::response('<html></html>', 200),
+    ]);
+
+    expect($check->check(Http::get('https://backstagephp.com'), new Crawler))->toBeFalse();
+});
+
+it('fails when the llms.txt file is empty', function () {
+    $check = new LlmsTxtCheck;
+    $check->url = 'https://backstagephp.com';
+
+    Http::fake([
+        'backstagephp.com/llms.txt' => Http::response('   ', 200),
+        '*' => Http::response('<html></html>', 200),
+    ]);
+
+    expect($check->check(Http::get('https://backstagephp.com'), new Crawler))->toBeFalse();
+});


### PR DESCRIPTION
Adds a new **AI** check that verifies the site provides an `llms.txt` file (llmstxt.org convention), which gives LLMs a curated Markdown overview of the site and improves AI/LLM visibility.

- New `Backstage\Seo\Checks\Ai\LlmsTxtCheck`
- Fetches `/llms.txt`; passes on a non-empty 200 response
- `continueAfterFailure = true`, low priority/weight (informational)
- Pest tests + translations (en, nl, fr, de, pt_BR) + README entry