### PR TITLE
feat: add AI crawler directives check (robots.txt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ These checks are available in the package. You can add or remove checks in the c
 ✅ The page does not have 'nofollow' set. <br>
 ✅ Robots.txt allows indexing. <br>
 
+### AI
+
+✅ Known AI crawlers (GPTBot, ClaudeBot, PerplexityBot, ...) are not blocked in robots.txt. <br>
+
 ### Content
 
 ✅ The page has an H1 tag and if it is used only once per page. <br>

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -1,4 +1,6 @@
 {
+    "The robots.txt file should not block known AI crawlers (such as GPTBot, ClaudeBot and PerplexityBot) unless that is intended, because blocking them removes the site from AI-powered search engines and assistants.": "Die robots.txt-Datei sollte bekannte KI-Crawler (wie GPTBot, ClaudeBot und PerplexityBot) nicht blockieren, sofern dies nicht beabsichtigt ist, da deren Blockierung die Website aus KI-gestützten Suchmaschinen und Assistenten entfernt.",
+    "failed.ai.ai_crawlers.blocked": "Die robots.txt-Datei blockiert die folgenden KI-Crawler, was die Sichtbarkeit bei KI und LLMs einschränkt: :actualValue.",
     "The page should have a canonical URL because this tells search engines which version of a page is the preferred one and prevents duplicate content issues.": "Die Seite sollte eine kanonische URL haben, da dies den Suchmaschinen mitteilt, welche Version einer Seite die bevorzugte ist, und Duplicate Content verhindert.",
     "failed.meta.canonical.missing": "Die Seite enthält keine kanonische URL, obwohl sie es sollte.",
     "failed.meta.canonical.broken": "Die Seite enthält eine defekte kanonische URL. Diese URL wurde gefunden: :actualValue.",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1,4 +1,6 @@
 {
+    "The robots.txt file should not block known AI crawlers (such as GPTBot, ClaudeBot and PerplexityBot) unless that is intended, because blocking them removes the site from AI-powered search engines and assistants.": "The robots.txt file should not block known AI crawlers (such as GPTBot, ClaudeBot and PerplexityBot) unless that is intended, because blocking them removes the site from AI-powered search engines and assistants.",
+    "failed.ai.ai_crawlers.blocked": "The robots.txt file blocks the following AI crawlers, which limits AI and LLM visibility: :actualValue.",
     "The page should have a canonical URL because this tells search engines which version of a page is the preferred one and prevents duplicate content issues.": "The page should have a canonical URL because this tells search engines which version of a page is the preferred one and prevents duplicate content issues.",
     "failed.meta.canonical.missing": "The page does not contain a canonical URL, while it should.",
     "failed.meta.canonical.broken": "The page contains a broken canonical URL. This URL was found: :actualValue.",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -1,4 +1,6 @@
 {
+    "The robots.txt file should not block known AI crawlers (such as GPTBot, ClaudeBot and PerplexityBot) unless that is intended, because blocking them removes the site from AI-powered search engines and assistants.": "Le fichier robots.txt ne devrait pas bloquer les robots d'IA connus (tels que GPTBot, ClaudeBot et PerplexityBot) sauf si c'est voulu, car les bloquer retire le site des moteurs de recherche et assistants basés sur l'IA.",
+    "failed.ai.ai_crawlers.blocked": "Le fichier robots.txt bloque les robots d'IA suivants, ce qui limite la visibilité auprès des IA et des LLM : :actualValue.",
     "The page should have a canonical URL because this tells search engines which version of a page is the preferred one and prevents duplicate content issues.": "La page devrait avoir une URL canonique car cela indique aux moteurs de recherche quelle version d'une page est la version préférée et évite le contenu dupliqué.",
     "failed.meta.canonical.missing": "La page ne contient pas d'URL canonique, alors qu'elle le devrait.",
     "failed.meta.canonical.broken": "La page contient une URL canonique cassée. Cette URL a été trouvée : :actualValue.",

--- a/resources/lang/nl.json
+++ b/resources/lang/nl.json
@@ -1,4 +1,6 @@
 {
+    "The robots.txt file should not block known AI crawlers (such as GPTBot, ClaudeBot and PerplexityBot) unless that is intended, because blocking them removes the site from AI-powered search engines and assistants.": "Het robots.txt-bestand zou bekende AI-crawlers (zoals GPTBot, ClaudeBot en PerplexityBot) niet moeten blokkeren tenzij dat de bedoeling is, omdat het blokkeren ervan de site verwijdert uit AI-gestuurde zoekmachines en assistenten.",
+    "failed.ai.ai_crawlers.blocked": "Het robots.txt-bestand blokkeert de volgende AI-crawlers, wat de AI- en LLM-zichtbaarheid beperkt: :actualValue.",
     "The page should have a canonical URL because this tells search engines which version of a page is the preferred one and prevents duplicate content issues.": "De pagina moet een canonieke URL hebben omdat dit zoekmachines vertelt welke versie van een pagina de voorkeursversie is en duplicate content voorkomt.",
     "failed.meta.canonical.missing": "De pagina bevat geen canonieke URL, terwijl dat wel zou moeten.",
     "failed.meta.canonical.broken": "De pagina bevat een kapotte canonieke URL. Deze URL is gevonden: :actualValue.",

--- a/resources/lang/pt_BR.json
+++ b/resources/lang/pt_BR.json
@@ -1,4 +1,6 @@
 {
+    "The robots.txt file should not block known AI crawlers (such as GPTBot, ClaudeBot and PerplexityBot) unless that is intended, because blocking them removes the site from AI-powered search engines and assistants.": "O arquivo robots.txt não deve bloquear rastreadores de IA conhecidos (como GPTBot, ClaudeBot e PerplexityBot), a menos que seja intencional, pois bloqueá-los remove o site dos mecanismos de busca e assistentes baseados em IA.",
+    "failed.ai.ai_crawlers.blocked": "O arquivo robots.txt bloqueia os seguintes rastreadores de IA, o que limita a visibilidade em IA e LLMs: :actualValue.",
     "The page should have a canonical URL because this tells search engines which version of a page is the preferred one and prevents duplicate content issues.": "A página deve ter uma URL canônica porque isso informa aos mecanismos de busca qual versão de uma página é a preferida e evita conteúdo duplicado.",
     "failed.meta.canonical.missing": "A página não contém uma URL canônica, embora devesse.",
     "failed.meta.canonical.broken": "A página contém uma URL canônica quebrada. Esta URL foi encontrada: :actualValue.",

--- a/src/Checks/Ai/AiCrawlerCheck.php
+++ b/src/Checks/Ai/AiCrawlerCheck.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Backstage\Seo\Checks\Ai;
+
+use Backstage\Seo\Interfaces\Check;
+use Backstage\Seo\Traits\PerformCheck;
+use Backstage\Seo\Traits\Translatable;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use Symfony\Component\DomCrawler\Crawler;
+
+class AiCrawlerCheck implements Check
+{
+    use PerformCheck,
+        Translatable;
+
+    public string $title = 'Known AI crawlers are not blocked in robots.txt';
+
+    public string $description = 'The robots.txt file should not block known AI crawlers (such as GPTBot, ClaudeBot and PerplexityBot) unless that is intended, because blocking them removes the site from AI-powered search engines and assistants.';
+
+    public string $priority = 'low';
+
+    public int $timeToFix = 15;
+
+    public int $scoreWeight = 1;
+
+    public bool $continueAfterFailure = true;
+
+    public ?string $failureReason;
+
+    public mixed $actualValue = null;
+
+    public mixed $expectedValue = null;
+
+    /**
+     * Well known AI crawler user agents.
+     */
+    protected array $aiCrawlers = [
+        'GPTBot',
+        'ChatGPT-User',
+        'OAI-SearchBot',
+        'ClaudeBot',
+        'Claude-Web',
+        'anthropic-ai',
+        'PerplexityBot',
+        'Google-Extended',
+        'CCBot',
+        'Applebot-Extended',
+        'Bytespider',
+        'Amazonbot',
+        'Meta-ExternalAgent',
+        'cohere-ai',
+    ];
+
+    public function check(Response $response, Crawler $crawler): bool
+    {
+        $base = $this->baseUrl($response);
+
+        if (! $base) {
+            return true;
+        }
+
+        $robots = Http::get($base.'/robots.txt');
+
+        // No robots.txt (or an error) means nothing is disallowed.
+        if (! $robots->successful() || trim((string) $robots->body()) === '') {
+            return true;
+        }
+
+        $groups = $this->parseRobots((string) $robots->body());
+
+        $blocked = [];
+
+        foreach ($this->aiCrawlers as $crawlerName) {
+            if ($this->isBlocked($crawlerName, $groups)) {
+                $blocked[] = $crawlerName;
+            }
+        }
+
+        if (count($blocked) === 0) {
+            return true;
+        }
+
+        $this->actualValue = $blocked;
+
+        $this->failureReason = __('failed.ai.ai_crawlers.blocked', [
+            'actualValue' => implode(', ', $blocked),
+        ]);
+
+        return false;
+    }
+
+    protected function isBlocked(string $crawlerName, array $groups): bool
+    {
+        $needle = strtolower($crawlerName);
+
+        foreach ($groups as $group) {
+            if (! $group['disallowAll']) {
+                continue;
+            }
+
+            if (in_array($needle, $group['agents'], true) || in_array('*', $group['agents'], true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Parse robots.txt into groups of user agents and whether they are fully disallowed.
+     */
+    protected function parseRobots(string $body): array
+    {
+        $groups = [];
+        $index = -1;
+        $lastLineWasAgent = false;
+
+        foreach (preg_split('/\r\n|\r|\n/', $body) as $line) {
+            $line = trim(preg_replace('/#.*$/', '', $line));
+
+            if ($line === '' || ! str_contains($line, ':')) {
+                continue;
+            }
+
+            [$field, $value] = explode(':', $line, 2);
+            $field = strtolower(trim($field));
+            $value = trim($value);
+
+            if ($field === 'user-agent') {
+                if (! $lastLineWasAgent) {
+                    $groups[] = ['agents' => [], 'disallowAll' => false];
+                    $index = count($groups) - 1;
+                }
+
+                $groups[$index]['agents'][] = strtolower($value);
+                $lastLineWasAgent = true;
+
+                continue;
+            }
+
+            if ($field === 'disallow' && $index >= 0 && $value === '/') {
+                $groups[$index]['disallowAll'] = true;
+            }
+
+            $lastLineWasAgent = false;
+        }
+
+        return $groups;
+    }
+
+    protected function baseUrl(Response $response): ?string
+    {
+        $url = $this->url ?? ($response->transferStats?->getHandlerStats()['url'] ?? null);
+
+        if (! $url) {
+            return null;
+        }
+
+        if (! preg_match('#^https?://#i', $url)) {
+            $url = 'https://'.$url;
+        }
+
+        $parts = parse_url($url);
+
+        if (empty($parts['host'])) {
+            return null;
+        }
+
+        $scheme = $parts['scheme'] ?? 'https';
+
+        return $scheme.'://'.$parts['host'].(isset($parts['port']) ? ':'.$parts['port'] : '');
+    }
+}

--- a/tests/Checks/Ai/AiCrawlerCheckTest.php
+++ b/tests/Checks/Ai/AiCrawlerCheckTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use Backstage\Seo\Checks\Ai\AiCrawlerCheck;
+use Illuminate\Support\Facades\Http;
+use Symfony\Component\DomCrawler\Crawler;
+
+it('passes when no robots.txt is present', function () {
+    $check = new AiCrawlerCheck;
+    $check->url = 'https://backstagephp.com';
+
+    Http::fake([
+        'backstagephp.com/robots.txt' => Http::response('Not found', 404),
+        '*' => Http::response('<html></html>', 200),
+    ]);
+
+    expect($check->check(Http::get('https://backstagephp.com'), new Crawler))->toBeTrue();
+});
+
+it('passes when AI crawlers are not blocked', function () {
+    $check = new AiCrawlerCheck;
+    $check->url = 'https://backstagephp.com';
+
+    Http::fake([
+        'backstagephp.com/robots.txt' => Http::response("User-agent: *\nDisallow: /admin", 200),
+        '*' => Http::response('<html></html>', 200),
+    ]);
+
+    expect($check->check(Http::get('https://backstagephp.com'), new Crawler))->toBeTrue();
+});
+
+it('fails when a specific AI crawler is fully disallowed', function () {
+    $check = new AiCrawlerCheck;
+    $check->url = 'https://backstagephp.com';
+
+    Http::fake([
+        'backstagephp.com/robots.txt' => Http::response("User-agent: GPTBot\nDisallow: /", 200),
+        '*' => Http::response('<html></html>', 200),
+    ]);
+
+    expect($check->check(Http::get('https://backstagephp.com'), new Crawler))->toBeFalse();
+    expect($check->actualValue)->toContain('GPTBot');
+});
+
+it('fails when a wildcard rule blocks the whole site', function () {
+    $check = new AiCrawlerCheck;
+    $check->url = 'https://backstagephp.com';
+
+    Http::fake([
+        'backstagephp.com/robots.txt' => Http::response("User-agent: *\nDisallow: /", 200),
+        '*' => Http::response('<html></html>', 200),
+    ]);
+
+    expect($check->check(Http::get('https://backstagephp.com'), new Crawler))->toBeFalse();
+});


### PR DESCRIPTION
Adds a new **AI** check that flags when robots.txt blocks well-known AI crawlers (GPTBot, ChatGPT-User, OAI-SearchBot, ClaudeBot, Claude-Web, anthropic-ai, PerplexityBot, Google-Extended, CCBot, Applebot-Extended, Bytespider, Amazonbot, Meta-ExternalAgent, cohere-ai).

- New `Backstage\Seo\Checks\Ai\AiCrawlerCheck`
- Parses robots.txt groups; fails when a listed AI crawler (or a global `*`) is fully disallowed
- No robots.txt = nothing blocked = pass
- Failure message notes this only limits AI/LLM visibility (blocking can be intentional)
- Pest tests + translations (en, nl, fr, de, pt_BR) + README entry