### PR TITLE
feat: scan models in chunks to keep memory flat

### DIFF
--- a/config/seo.php
+++ b/config/seo.php
@@ -155,6 +155,18 @@ return [
     */
     'models' => [],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Chunk size
+    |--------------------------------------------------------------------------
+    |
+    | When scanning models, records are read in chunks of this size instead of
+    | loading every record into memory at once. Lower this for large tables on
+    | memory-constrained environments.
+    |
+    */
+    'chunk_size' => 100,
+
     'http' => [
         /*
         |--------------------------------------------------------------------------

--- a/src/Commands/SeoScan.php
+++ b/src/Commands/SeoScan.php
@@ -224,7 +224,7 @@ class SeoScan extends Command
             $items = $items->{$scope}();
         }
 
-        $items->get()->filter->url->map(function ($model) {
+        $items->lazyById(config('seo.chunk_size', 100))->filter->url->each(function ($model) {
             $this->progress?->start();
 
             $seo = $model->seoScore();

--- a/tests/Commands/ChunkedModelScanTest.php
+++ b/tests/Commands/ChunkedModelScanTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Backstage\Seo\Checks\Content\MultipleHeadingCheck;
+use Backstage\Seo\Tests\Support\Product;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function () {
+    Schema::create('products', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('url')->nullable();
+    });
+
+    Http::fake([
+        '*' => Http::response('<html><head><title>Test</title></head><body><h1>Test</h1></body></html>'),
+    ]);
+
+    config(['seo.database.save' => false]);
+    config(['seo.check_routes' => false]);
+    config(['seo.checks' => [MultipleHeadingCheck::class]]);
+    config(['seo.models' => [Product::class]]);
+});
+
+afterEach(function () {
+    Schema::dropIfExists('products');
+});
+
+it('scans every model record that has a url and skips the rest', function () {
+    foreach (range(1, 5) as $i) {
+        Product::create(['url' => "https://example.com/product/{$i}"]);
+    }
+
+    // Records without a url must be skipped.
+    Product::create(['url' => null]);
+    Product::create(['url' => null]);
+
+    $this->artisan('seo:scan')
+        ->expectsOutputToContain('on 5 pages')
+        ->assertExitCode(0);
+});
+
+it('reads model records in chunks instead of loading them all at once', function () {
+    foreach (range(1, 5) as $i) {
+        Product::create(['url' => "https://example.com/product/{$i}"]);
+    }
+
+    config(['seo.chunk_size' => 2]);
+
+    DB::connection()->enableQueryLog();
+
+    $this->artisan('seo:scan')->assertExitCode(0);
+
+    $productSelects = collect(DB::connection()->getQueryLog())
+        ->filter(fn ($query) => str_contains($query['query'], 'from "products"')
+            && str_starts_with(trim($query['query']), 'select'));
+
+    // With chunked reads (chunk size 2 over 5 records) the table is queried
+    // in several batches, not in a single unbounded select.
+    expect($productSelects->count())->toBeGreaterThan(1);
+});

--- a/tests/Support/Product.php
+++ b/tests/Support/Product.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Backstage\Seo\Tests\Support;
+
+use Backstage\Seo\SeoInterface;
+use Backstage\Seo\Traits\HasSeoScore;
+use Illuminate\Database\Eloquent\Model;
+
+class Product extends Model implements SeoInterface
+{
+    use HasSeoScore;
+
+    protected $table = 'products';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function getUrlAttribute(): ?string
+    {
+        return $this->attributes['url'] ?? null;
+    }
+}


### PR DESCRIPTION
## What

Replace the eager `$items->get()` in `calculateScoreForModel` with `lazyById(config('seo.chunk_size', 100))` so large model tables are read in batches instead of loaded into memory all at once.

## Why

On a large site (e.g. a webshop with 20k product pages) `->get()` loads every record into memory at once, risking exhaustion. `lazyById()` streams records in batches and keeps memory flat regardless of table size. Scan output and stored results are identical.

## Changes

- `SeoScan::calculateScoreForModel()` now uses `lazyById()`.
- New config key `seo.chunk_size` (default `100`).

## Tests

- All model records with a `url` are scanned; records without a `url` are skipped.
- The table is queried in multiple batches (keyset pagination) rather than a single unbounded select.

## Notes

`lazyById()` does keyset pagination on the primary key. This works with auto-increment and ULID/UUID keys alike; scan order is irrelevant since each page is scored independently.