### PR TITLE
feat: parallel worker tuning for queued scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Easily configure which routes to scan, exclude or include specific checks or eve
     -   [Scanning a single route](#scanning-a-single-route)
     -   [Scanning routes in an SPA application](#scanning-routes-in-an-spa-application)
     -   [Throttling](#throttling)
+    -   [Scanning large sites](#scanning-large-sites)
     -   [Scan model urls](#scan-model-urls)
     -   [Saving scans into the database](#saving-scans-into-the-database)
     -   [Listening to events](#listening-to-events)
@@ -293,6 +294,43 @@ If you want to throttle the requests, you can set the `throttle` option to `true
     'requests_per_minute' => 10,
 ],
 ```
+
+### Scanning large sites
+
+For large sites (think a webshop with thousands of product pages) a single synchronous run is slow and can hit the queue job timeout. The scanner can instead split the work into batched queue jobs and process them with multiple workers.
+
+Run the scan as a batch of queued jobs:
+
+```bash
+php artisan seo:scan --queue
+```
+
+This creates one scan record, splits the routes and model records into chunks, and dispatches them as a `Bus::batch` of `ScanChunk` jobs. When the batch finishes, the scan record is finalized (page count, failed checks, duration) and the `ScanCompleted` event is fired.
+
+Memory stays flat regardless of how many model records you have: records are read in batches using `lazyById()` rather than loaded all at once. The batch size is controlled by `chunk_size`, which is also the number of pages each queue job scans:
+
+```php
+// config/seo.php
+'chunk_size' => 100,
+```
+
+Dispatch the jobs onto a dedicated queue so you can scale its workers independently:
+
+```php
+// config/seo.php
+'queue' => 'seo',
+```
+
+```bash
+# Run several workers against the seo queue to scan in parallel
+php artisan queue:work --queue=seo
+php artisan queue:work --queue=seo
+php artisan queue:work --queue=seo
+```
+
+> Use a real queue connection (Redis, database, …) for parallel workers — the `sync` driver runs jobs inline and cannot run them in parallel.
+
+**Throttling across parallel workers.** The `throttle` setting (see above) is enforced across all workers when scanning with `--queue`, using a cache-backed rate limiter. Because each job scans `chunk_size` pages, the limiter allows roughly `requests_per_minute / chunk_size` jobs per minute. For this to be shared between workers, use a shared cache store (Redis, Memcached or database) — not the `array` driver.
 
 ### Scan model urls
 

--- a/config/seo.php
+++ b/config/seo.php
@@ -109,6 +109,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Queue
+    |--------------------------------------------------------------------------
+    |
+    | The queue that the batched scan jobs (seo:scan --queue) are dispatched
+    | onto. Set this to a dedicated queue so you can scale its workers
+    | independently. Leave null to use the default queue.
+    |
+    */
+    'queue' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Domains (DNS resolving)
     |--------------------------------------------------------------------------
     |

--- a/src/Commands/SeoScan.php
+++ b/src/Commands/SeoScan.php
@@ -128,6 +128,7 @@ class SeoScan extends Command
 
         Bus::batch($jobs)
             ->name('SEO scan #'.$scanId)
+            ->onQueue(config('seo.queue'))
             ->finally(function () use ($scanId) {
                 if ($scan = SeoScanModel::find($scanId)) {
                     app(ScanFinalizer::class)->finalize($scan);

--- a/src/Jobs/ScanChunk.php
+++ b/src/Jobs/ScanChunk.php
@@ -9,6 +9,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\RateLimited;
 use Illuminate\Queue\SerializesModels;
 
 class ScanChunk implements ShouldQueue
@@ -30,6 +31,19 @@ class ScanChunk implements ShouldQueue
         public ?string $model = null,
         public array $ids = [],
     ) {}
+
+    /**
+     * Throttle chunk jobs across all workers when throttling is enabled, so
+     * parallel workers collectively respect the configured request rate.
+     *
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return config('seo.throttle.enabled')
+            ? [new RateLimited('seo-scan')]
+            : [];
+    }
 
     public function handle(PageScanRunner $runner): void
     {

--- a/src/SeoServiceProvider.php
+++ b/src/SeoServiceProvider.php
@@ -4,12 +4,28 @@ namespace Backstage\Seo;
 
 use Backstage\Seo\Commands\SeoScan;
 use Backstage\Seo\Commands\SeoScanUrl;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Support\Facades\RateLimiter;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
 class SeoServiceProvider extends PackageServiceProvider
 {
+    public function packageBooted(): void
+    {
+        RateLimiter::for('seo-scan', function () {
+            if (! config('seo.throttle.enabled') || ! config('seo.throttle.requests_per_minute')) {
+                return Limit::none();
+            }
+
+            $chunkSize = max(1, (int) config('seo.chunk_size', 100));
+            $jobsPerMinute = max(1, intdiv((int) config('seo.throttle.requests_per_minute'), $chunkSize));
+
+            return Limit::perMinute($jobsPerMinute);
+        });
+    }
+
     public function configurePackage(Package $package): void
     {
         $package

--- a/tests/Commands/QueueConfigTest.php
+++ b/tests/Commands/QueueConfigTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use Backstage\Seo\Checks\Content\MultipleHeadingCheck;
+use Backstage\Seo\Tests\Support\Product;
+use Illuminate\Bus\PendingBatch;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function () {
+    config(['seo.database.connection' => 'testing']);
+    config(['seo.database.save' => true]);
+    config(['seo.checks' => [MultipleHeadingCheck::class]]);
+    config(['seo.check_routes' => false]);
+    config(['seo.models' => [Product::class]]);
+    $this->loadMigrationsFrom(__DIR__.'/../../database/migrations');
+
+    Schema::create('products', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('url')->nullable();
+    });
+
+    Product::create(['url' => 'https://example.com/product/1']);
+});
+
+afterEach(function () {
+    Schema::dropIfExists('products');
+});
+
+it('dispatches the scan batch onto the configured queue', function () {
+    config(['seo.queue' => 'seo']);
+
+    Bus::fake();
+
+    $this->artisan('seo:scan --queue')->assertExitCode(0);
+
+    Bus::assertBatched(fn (PendingBatch $batch) => $batch->queue() === 'seo');
+});
+
+it('uses the default queue when no queue is configured', function () {
+    config(['seo.queue' => null]);
+
+    Bus::fake();
+
+    $this->artisan('seo:scan --queue')->assertExitCode(0);
+
+    Bus::assertBatched(fn (PendingBatch $batch) => $batch->queue() === null);
+});

--- a/tests/Jobs/ScanChunkThrottleTest.php
+++ b/tests/Jobs/ScanChunkThrottleTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Backstage\Seo\Jobs\ScanChunk;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Queue\Middleware\RateLimited;
+use Illuminate\Support\Facades\RateLimiter;
+
+it('rate limits chunk jobs when throttling is enabled', function () {
+    config(['seo.throttle.enabled' => true]);
+    config(['seo.throttle.requests_per_minute' => 60]);
+
+    $middleware = (new ScanChunk(scanId: 1))->middleware();
+
+    expect($middleware)->toHaveCount(1)
+        ->and($middleware[0])->toBeInstanceOf(RateLimited::class);
+});
+
+it('does not rate limit chunk jobs when throttling is disabled', function () {
+    config(['seo.throttle.enabled' => false]);
+
+    expect((new ScanChunk(scanId: 1))->middleware())->toBe([]);
+});
+
+it('registers the seo-scan limiter derived from requests per minute and chunk size', function () {
+    config(['seo.throttle.enabled' => true]);
+    config(['seo.throttle.requests_per_minute' => 120]);
+    config(['seo.chunk_size' => 10]);
+
+    $limiter = RateLimiter::limiter('seo-scan');
+
+    expect($limiter)->not->toBeNull();
+
+    $limit = $limiter(new ScanChunk(scanId: 1));
+
+    // 120 requests/min over chunks of 10 pages => 12 jobs/min.
+    expect($limit)->toBeInstanceOf(Limit::class)
+        ->and($limit->maxAttempts)->toBe(12);
+});


### PR DESCRIPTION
## What

Tune the batched queue scan (#119) for running across multiple parallel workers: a dedicated queue and distributed rate limiting.

> Stacked on #119 — base branch is `feature/batched-queue-scanning`, so merge that first. The diff here is only the parallel-worker changes.

## Why

Once the scan is batched (#119), parallelism comes for free from multiple queue workers — but two things are needed to do it well: a queue you can scale independently, and a rate limiter that holds *across* workers (the existing per-process throttle does not).

## Changes

- New config `seo.queue` (default `null`): batched scan jobs are dispatched onto this queue so its workers can be scaled independently.
- Distributed rate limiting: a cache-backed limiter `seo-scan` is attached to `ScanChunk` via job middleware when `seo.throttle.enabled` is true. Derived from `requests_per_minute / chunk_size` (≈ jobs per minute). No limiter when throttling is disabled.
- README: new "Scanning large sites" section covering `--queue`, `chunk_size`, `seo.queue`, parallel workers and how throttling behaves across workers.

## Tests

- The batch is dispatched onto the configured queue (and the default queue when unset).
- `ScanChunk` carries the rate-limiter middleware when throttling is enabled, and none when disabled.
- The `seo-scan` limiter resolves to the expected per-minute rate.

## Notes

For the limiter to be shared between workers, use a shared cache store (Redis/Memcached/database) — not the `array` driver.