### PR TITLE
fix: isolate check failures so one bad page/check can't abort a scan (#121)

### DIFF
--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -107,6 +107,7 @@
     "failed.content.broken_links": "Die Seite enthält defekte Links. Diese Links wurden gefunden: :actualValue.",
     "failed.content.length": "Der Inhalt enthält :actualValue Zeichen. Er sollte mindestens :expectedValue Zeichen enthalten.",
     "failed.content.length.parse": "Wir konnten den Inhalt dieser Seite nicht analysieren, bitte versuchen Sie es noch einmal.",
+    "failed.check.error": "Diese Prüfung konnte aufgrund eines unerwarteten Fehlers nicht abgeschlossen werden.",
     "failed.content.mixed_content": "Die Seite enthält Links zu unsicheren Adressen, obwohl dies nicht der Fall sein sollte. Diese Links wurden gefunden: :actualValue.",
     "failed.content.multiple_h1": "Die Seite enthält mehrere h1-Tags, obwohl sie das nicht sollte. Diese Tags wurden gefunden: :actualValue.",
     "failed.content.no_heading": "Die Seite enthält keine h1-Tags, obwohl sie welche enthalten sollte.",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -106,6 +106,7 @@
     "failed.content.broken_links": "The page contains broken links. These links were found: :actualValue.",
     "failed.content.length": "The content is :actualValue characters long. It should be at least :expectedValue characters long.",
     "failed.content.length.parse": "We were unable to parse the content of this page, please try again.",
+    "failed.check.error": "This check could not be completed because of an unexpected error.",
     "failed.content.mixed_content": "The page contains links to insecure addresses, while it should not. These links were found :actualValue.",
     "failed.content.multiple_h1": "The page contains multiple h1 tags, while it should not. These tags were found :actualValue.",
     "failed.content.no_heading": "The page does not contain any h1 tag, while it should.",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -106,6 +106,7 @@
     "failed.content.broken_links": "La page contient des liens brisés. Ces liens ont été trouvés : :actualValue.",
     "failed.content.length": "Le contenu comporte :actualValue caractères. Il devrait comporter au moins :expectedValue caractères.",
     "failed.content.length.parse": "Nous n'avons pas pu analyser le contenu de cette page, veuillez réessayer.",
+    "failed.check.error": "Cette vérification n'a pas pu être effectuée en raison d'une erreur inattendue.",
     "failed.content.mixed_content": "La page contient des liens vers des adresses non sécurisées, alors qu'elle ne devrait pas. Ces liens ont été trouvés : :actualValue.",
     "failed.content.multiple_h1": "La page contient plusieurs balises h1, alors qu'elle ne devrait pas. Ces balises ont été trouvées : :actualValue.",
     "failed.content.no_heading": "La page ne contient aucune balise h1, alors qu'elle devrait en contenir.",

--- a/resources/lang/nl.json
+++ b/resources/lang/nl.json
@@ -106,6 +106,7 @@
     "failed.content.broken_links": "De pagina bevat kapotte links. Deze links zijn gevonden: :actualValue.",
     "failed.content.length": "De inhoud is :actualValue tekens lang. Dit zou minstens :expectedValue tekens moeten zijn.",
     "failed.content.length.parse": "We konden de inhoud van deze pagina niet analyseren. Probeer het opnieuw.",
+    "failed.check.error": "Deze controle kon niet worden voltooid vanwege een onverwachte fout.",
     "failed.content.mixed_content": "De pagina bevat links naar onveilige adressen, terwijl dat niet zou moeten. Deze links zijn gevonden: :actualValue.",
     "failed.content.multiple_h1": "De pagina bevat meerdere h1-tags, terwijl dat niet zou moeten. Deze tags zijn gevonden: :actualValue.",
     "failed.content.no_heading": "De pagina bevat geen h1-tag, terwijl dat wel zou moeten.",

--- a/resources/lang/pt_BR.json
+++ b/resources/lang/pt_BR.json
@@ -106,6 +106,7 @@
     "failed.content.broken_links": "A página contém links quebrados. Links encontrados: :actualValue.",
     "failed.content.length": "O conteúdo tem :actualValue caracteres, mas deve conter ao menos :expectedValue caracteres.",
     "failed.content.length.parse": "Não foi possível analisar o conteúdo desta página. Tente novamente.",
+    "failed.check.error": "Esta verificação não pôde ser concluída devido a um erro inesperado.",
     "failed.content.mixed_content": "A página contém links para endereços inseguros, mas não deveria. Links encontrados :actualValue.",
     "failed.content.multiple_h1": "A página contém várias tags h1, mas não deveria. Tags encontradas :actualValue.",
     "failed.content.no_heading": "A página não contém nenhuma tag h1, embora deveria.",

--- a/src/Checks/Content/ContentLengthCheck.php
+++ b/src/Checks/Content/ContentLengthCheck.php
@@ -61,7 +61,15 @@ class ContentLengthCheck implements Check
 
         $readability = new Readability($body);
 
-        $readability->init();
+        // php-readability can throw on real-world HTML (e.g. j0k3r/php-readability#96,
+        // "Undefined array key 0"). Degrade gracefully instead of aborting the scan.
+        try {
+            $readability->init();
+        } catch (\Throwable $e) {
+            $this->failureReason = __('failed.content.length.parse');
+
+            return null;
+        }
 
         $textContent = $readability->getContent()->textContent;
 

--- a/src/Jobs/ScanChunk.php
+++ b/src/Jobs/ScanChunk.php
@@ -7,6 +7,7 @@ use Backstage\Seo\Services\PageScanRunner;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Middleware\RateLimited;
@@ -54,7 +55,7 @@ class ScanChunk implements ShouldQueue
         }
 
         foreach ($this->urls as $url) {
-            $runner->scan($scan, $url, useJavascript: config('seo.javascript'));
+            $this->scanSafely($runner, $scan, $url);
         }
 
         if ($this->model && ! empty($this->ids)) {
@@ -64,7 +65,20 @@ class ScanChunk implements ShouldQueue
                 ->whereIn($instance->getKeyName(), $this->ids)
                 ->get()
                 ->filter->url
-                ->each(fn ($model) => $runner->scan($scan, $model->url, $model));
+                ->each(fn ($model) => $this->scanSafely($runner, $scan, $model->url, $model));
+        }
+    }
+
+    /**
+     * Scan a single page, isolating failures so one unscannable page can't
+     * abort the whole chunk and lose every other page in it.
+     */
+    private function scanSafely(PageScanRunner $runner, SeoScanModel $scan, string $url, ?Model $model = null): void
+    {
+        try {
+            $runner->scan($scan, $url, $model, useJavascript: config('seo.javascript'));
+        } catch (\Throwable $e) {
+            report($e);
         }
     }
 }

--- a/src/Traits/PerformCheck.php
+++ b/src/Traits/PerformCheck.php
@@ -16,15 +16,30 @@ trait PerformCheck
 
         $this->useJavascript = $data['javascriptResponse'] ?? false;
 
+        $threw = false;
+
         if (! in_array('exit', $data)) {
-            $result = $this->check($data['response'], $data['crawler']);
+            try {
+                $result = $this->check($data['response'], $data['crawler']);
+            } catch (\Throwable $e) {
+                // A single check throwing must not abort the whole pipeline
+                // (and, in queued scans, the whole ScanChunk). Record it as a
+                // failed check and let the remaining checks run.
+                $threw = true;
+                $result = false;
+                $this->failureReason = __('failed.check.error');
+
+                report($e);
+            }
         }
 
         $result = $result ?? false;
 
         $data = $this->setResult($data, $result);
 
-        if (! $result && ! $this->continueAfterFailure) {
+        // Only honour fail-fast (continueAfterFailure = false) for genuine check
+        // failures, never for unexpected exceptions.
+        if (! $result && ! $this->continueAfterFailure && ! $threw) {
             $data['exit'] = true;
         }
 

--- a/tests/Jobs/ScanChunkTest.php
+++ b/tests/Jobs/ScanChunkTest.php
@@ -3,11 +3,14 @@
 use Backstage\Seo\Checks\Content\MultipleHeadingCheck;
 use Backstage\Seo\Jobs\ScanChunk;
 use Backstage\Seo\Models\SeoScan as SeoScanModel;
+use Backstage\Seo\SeoScore;
 use Backstage\Seo\Services\PageScanRunner;
 use Backstage\Seo\Tests\Support\Product;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Schema;
+use Symfony\Component\Console\Helper\ProgressBar;
 
 beforeEach(function () {
     config(['seo.database.connection' => 'testing']);
@@ -38,6 +41,37 @@ it('scans a chunk of urls and persists a score per url', function () {
     ]))->handle(app(PageScanRunner::class));
 
     expect(DB::connection('testing')->table('seo_scores')->count())->toBe(2);
+});
+
+it('continues scanning the chunk when one page throws', function () {
+    $scan = SeoScanModel::create(['total_checks' => 1, 'started_at' => now()]);
+
+    $runner = new class extends PageScanRunner
+    {
+        public array $scanned = [];
+
+        public function scan(?SeoScanModel $scan, string $url, ?Model $model = null, bool $useJavascript = false, ?ProgressBar $progress = null): SeoScore
+        {
+            if (str_contains($url, 'boom')) {
+                throw new RuntimeException('kaboom');
+            }
+
+            $this->scanned[] = $url;
+
+            return new SeoScore;
+        }
+    };
+
+    (new ScanChunk(scanId: $scan->id, urls: [
+        'https://example.com/a',
+        'https://example.com/boom',
+        'https://example.com/c',
+    ]))->handle($runner);
+
+    expect($runner->scanned)->toBe([
+        'https://example.com/a',
+        'https://example.com/c',
+    ]);
 });
 
 it('scans a chunk of model records by id and persists the model reference', function () {

--- a/tests/Support/ThrowingCheck.php
+++ b/tests/Support/ThrowingCheck.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Backstage\Seo\Tests\Support;
+
+use Backstage\Seo\Interfaces\Check;
+use Backstage\Seo\Traits\PerformCheck;
+use Backstage\Seo\Traits\Translatable;
+use Illuminate\Http\Client\Response;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * A check that always throws, used to verify that a single misbehaving check
+ * (or a misbehaving dependency it calls) cannot abort the whole scan.
+ */
+class ThrowingCheck implements Check
+{
+    use PerformCheck,
+        Translatable;
+
+    public string $title = 'Throwing check';
+
+    public string $description = 'A check that throws to exercise error isolation.';
+
+    public string $priority = 'low';
+
+    public int $timeToFix = 0;
+
+    public int $scoreWeight = 5;
+
+    public bool $continueAfterFailure = true;
+
+    public ?string $failureReason;
+
+    public mixed $actualValue = null;
+
+    public mixed $expectedValue = null;
+
+    public function check(Response $response, Crawler $crawler): bool
+    {
+        throw new \RuntimeException('boom');
+    }
+}

--- a/tests/Traits/PerformCheckTest.php
+++ b/tests/Traits/PerformCheckTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Backstage\Seo\Checks\Content\MultipleHeadingCheck;
+use Backstage\Seo\Facades\Seo;
+use Backstage\Seo\Tests\Support\ThrowingCheck;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    config(['seo.database.save' => false]);
+    config(['seo.checks' => [
+        ThrowingCheck::class,
+        MultipleHeadingCheck::class,
+    ]]);
+
+    Http::fake([
+        '*' => Http::response('<html><head><title>Test</title></head><body><h1>Test</h1></body></html>'),
+    ]);
+});
+
+it('records a throwing check as failed without aborting the rest of the scan', function () {
+    $score = Seo::check('https://example.com');
+
+    expect($score->getFailedChecks()->keys())->toContain(ThrowingCheck::class)
+        ->and($score->getFailedChecks()->get(ThrowingCheck::class)->failureReason)
+        ->toBe(__('failed.check.error'));
+});
+
+it('still runs the remaining checks after one check throws', function () {
+    $score = Seo::check('https://example.com');
+
+    expect($score->getSuccessfulChecks()->keys())->toContain(MultipleHeadingCheck::class);
+});


### PR DESCRIPTION
## Summary

Fixes #121.

When scanning real-world pages, a crash inside `j0k3r/php-readability` (invoked by `ContentLengthCheck`) raised `ErrorException: Undefined array key 0` and aborted the scan. Worse, because checks run through a single pipeline with no per-check error handling, one thrown check killed the whole page scan — and in queued scans, the whole batched `ScanChunk`, losing up to `chunk_size` (default 100) otherwise-scannable pages.

Rather than vendoring the dependency, this closes the **robustness gap** so any misbehaving check or dependency degrades gracefully.

## Changes

1. **`PerformCheck` trait (core fix)** — each check runs in a `try/catch`. A thrown check is recorded as a *failed* check (reason `failed.check.error`), reported via `report()`, and the pipeline continues. An exception never triggers fail-fast (`continueAfterFailure`), so it can't abort the scan.
2. **`ScanChunk` job** — a `scanSafely()` wrapper isolates each page, so one unscannable page can no longer take down the rest of the chunk in a queued scan.
3. **`ContentLengthCheck`** — guards the `Readability->init()` call (the exact crash site from [j0k3r/php-readability#96](https://github.com/j0k3r/php-readability/issues/96)), degrading to the existing `failed.content.length.parse` reason.
4. Added the `failed.check.error` translation key to all locales (en/nl/de/fr/pt_BR).

## Tests

- `ScanChunk` continues scanning the chunk when one page throws.
- A throwing check is recorded as failed (with the right reason) without aborting the scan.
- The remaining checks still run after one check throws.

Full suite: **157 passed, 3 pre-existing skips**. Pint clean.

## Follow-up

The upstream `array_filter`/`$children[0]` bug still lives in `j0k3r/php-readability` 2.0.8. These changes make the scanner resilient to it, but `ContentLengthCheck` will still register as failed on affected pages (now with a clean parse-failure reason). Once [j0k3r/php-readability#96](https://github.com/j0k3r/php-readability/issues/96) releases, bumping the `^2.0` constraint restores that check.
