### PR TITLE
fix: allow throttled chunk jobs to retry instead of failing as MaxAttempts (#123)

### DIFF
--- a/config/seo.php
+++ b/config/seo.php
@@ -111,9 +111,10 @@ return [
          | queue, and each release counts as an attempt. This is how long a
          | throttled chunk may keep being released-and-retried before it is
          | allowed to fail, so it can ride out throttle waves on large sites.
-         | Set to null to fall back to the worker's --tries instead.
+         | At the slowest throttle (1 job/min) 6h covers ~36k URLs; raise it
+         | for bigger sites, or set null to fall back to the worker's --tries.
          */
-        'retry_until_hours' => 24,
+        'retry_until_hours' => 6,
     ],
 
     /*

--- a/config/seo.php
+++ b/config/seo.php
@@ -105,6 +105,15 @@ return [
     'throttle' => [
         'enabled' => false,
         'requests_per_minute' => null,
+
+        /*
+         | The rate limiter throttles by releasing chunk jobs back onto the
+         | queue, and each release counts as an attempt. This is how long a
+         | throttled chunk may keep being released-and-retried before it is
+         | allowed to fail, so it can ride out throttle waves on large sites.
+         | Set to null to fall back to the worker's --tries instead.
+         */
+        'retry_until_hours' => 24,
     ],
 
     /*

--- a/src/Jobs/ScanChunk.php
+++ b/src/Jobs/ScanChunk.php
@@ -17,9 +17,14 @@ class ScanChunk implements ShouldQueue
 {
     use Batchable, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public $tries = 1;
-
     public $timeout = 600;
+
+    /**
+     * Fail the job only after this many uncaught exceptions. Rate-limit
+     * releases are not exceptions, so they don't consume this budget — this
+     * just stops a genuinely broken chunk from retrying until retryUntil().
+     */
+    public $maxExceptions = 3;
 
     /**
      * @param  array<int, string>  $urls  Route URLs to scan.
@@ -44,6 +49,27 @@ class ScanChunk implements ShouldQueue
         return config('seo.throttle.enabled')
             ? [new RateLimited('seo-scan')]
             : [];
+    }
+
+    /**
+     * Bound retries by time rather than by a hard attempt count.
+     *
+     * The RateLimited middleware throttles by releasing the job back onto the
+     * queue, and each release counts as an attempt — so a hard `$tries` cap
+     * would fail every throttled chunk on its next pickup instead of resuming
+     * it. A time bound lets the job ride out throttle waves while still
+     * guaranteeing it can't loop forever. When throttling is off we return
+     * null so the worker's own --tries governs as usual.
+     */
+    public function retryUntil(): ?\DateTimeInterface
+    {
+        if (! config('seo.throttle.enabled')) {
+            return null;
+        }
+
+        $hours = (int) config('seo.throttle.retry_until_hours', 24);
+
+        return $hours > 0 ? now()->addHours($hours) : null;
     }
 
     public function handle(PageScanRunner $runner): void

--- a/src/Jobs/ScanChunk.php
+++ b/src/Jobs/ScanChunk.php
@@ -67,7 +67,7 @@ class ScanChunk implements ShouldQueue
             return null;
         }
 
-        $hours = (int) config('seo.throttle.retry_until_hours', 24);
+        $hours = (int) config('seo.throttle.retry_until_hours', 6);
 
         return $hours > 0 ? now()->addHours($hours) : null;
     }

--- a/tests/Jobs/ScanChunkThrottleTest.php
+++ b/tests/Jobs/ScanChunkThrottleTest.php
@@ -21,6 +21,36 @@ it('does not rate limit chunk jobs when throttling is disabled', function () {
     expect((new ScanChunk(scanId: 1))->middleware())->toBe([]);
 });
 
+it('does not hard-cap retries, so rate-limit releases are not failed as MaxAttemptsExceeded', function () {
+    // A declared `$tries = 1` would fail every throttled chunk the moment the
+    // RateLimited middleware releases it back onto the queue.
+    expect((new ReflectionClass(ScanChunk::class))->hasProperty('tries'))->toBeFalse();
+});
+
+it('allows time-bound retries while throttling is enabled', function () {
+    config(['seo.throttle.enabled' => true]);
+    config(['seo.throttle.retry_until_hours' => 12]);
+
+    $retryUntil = (new ScanChunk(scanId: 1))->retryUntil();
+
+    expect($retryUntil)->toBeInstanceOf(DateTimeInterface::class)
+        ->and($retryUntil->getTimestamp())->toBeGreaterThan(now()->addHours(11)->getTimestamp())
+        ->and($retryUntil->getTimestamp())->toBeLessThanOrEqual(now()->addHours(12)->getTimestamp());
+});
+
+it('does not bound retries by time when throttling is disabled', function () {
+    config(['seo.throttle.enabled' => false]);
+
+    expect((new ScanChunk(scanId: 1))->retryUntil())->toBeNull();
+});
+
+it('lets retry_until_hours be disabled so the worker --tries governs', function () {
+    config(['seo.throttle.enabled' => true]);
+    config(['seo.throttle.retry_until_hours' => null]);
+
+    expect((new ScanChunk(scanId: 1))->retryUntil())->toBeNull();
+});
+
 it('registers the seo-scan limiter derived from requests per minute and chunk size', function () {
     config(['seo.throttle.enabled' => true]);
     config(['seo.throttle.requests_per_minute' => 120]);


### PR DESCRIPTION
## Summary

Fixes #123.

`ScanChunk` declared `public $tries = 1;` **and** applied the `RateLimited('seo-scan')` job middleware — two fundamentally incompatible settings. `RateLimited` throttles by **releasing the job back onto the queue**, and each release counts as an attempt. So with `$tries = 1`, every throttled chunk failed with `MaxAttemptsExceeded` on its next pickup: only chunks running inside the very first rate window survived, and all subsequent pages were silently lost. This broke the documented "scanning large sites + throttling" use case — exactly when throttling matters. The hard `$tries = 1` also overrode the worker's `--tries` flag, so operators couldn't fix it from the CLI.

## Changes

- **Drop the hard `$tries = 1`** so a rate-limit release no longer fails the job, and operators can govern attempts via `--tries` when throttling is off.
- **Bound retries by time** with `retryUntil()` — default 6h, configurable via the new `seo.throttle.retry_until_hours` (set `null` to fall back to the worker `--tries`). Returns `null` when throttling is disabled, so non-throttled behaviour is unchanged. This lets a throttled chunk ride out throttle waves while still guaranteeing it can't loop forever.
- **Add `maxExceptions = 3`** so a genuinely broken chunk still fails fast, while rate-limit releases (which are not exceptions) don't consume the budget.

## Tests

- No hard `tries` cap is declared on the job (so releases aren't failed as `MaxAttemptsExceeded`).
- `retryUntil()` returns a future time within the configured window when throttling is enabled.
- `retryUntil()` returns `null` when throttling is disabled and when `retry_until_hours` is `null`.

Full suite: **161 passed, 3 pre-existing skips**. Pint clean.

## Note

Builds on the per-page/per-check exception isolation from #121 (merged in #122): `handle()` no longer throws on a single bad page, so the retry budget is spent only on real rate-limit releases.

