### PR TITLE
test: make the suite hermetic so CI stops failing on live-network timeouts

### DIFF
--- a/src/Checks/Configuration/RobotsCheck.php
+++ b/src/Checks/Configuration/RobotsCheck.php
@@ -6,8 +6,9 @@ use Backstage\Seo\Interfaces\Check;
 use Backstage\Seo\Traits\PerformCheck;
 use Backstage\Seo\Traits\Translatable;
 use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
 use Symfony\Component\DomCrawler\Crawler;
-use vipnytt\RobotsTxtParser\UriClient;
+use vipnytt\RobotsTxtParser\TxtClient;
 
 class RobotsCheck implements Check
 {
@@ -34,7 +35,7 @@ class RobotsCheck implements Check
 
     public function check(Response $response, Crawler $crawler): bool
     {
-        $url = $response->transferStats?->getHandlerStats()['url'] ?? null;
+        $url = $this->url ?? ($response->transferStats?->getHandlerStats()['url'] ?? null);
 
         if (! $url) {
             $this->failureReason = __('failed.configuration.robots.missing_url');
@@ -42,7 +43,27 @@ class RobotsCheck implements Check
             return false;
         }
 
-        $client = new UriClient($url);
+        if (! preg_match('#^https?://#i', $url)) {
+            $url = 'https://'.$url;
+        }
+
+        $parts = parse_url($url);
+
+        if (empty($parts['host'])) {
+            $this->failureReason = __('failed.configuration.robots.missing_url');
+
+            return false;
+        }
+
+        $base = ($parts['scheme'] ?? 'https').'://'.$parts['host'].(isset($parts['port']) ? ':'.$parts['port'] : '');
+
+        // Fetch robots.txt through Laravel's HTTP client (rather than vipnytt's
+        // own UriClient) so it can be faked in tests and stays consistent with
+        // the other robots-aware checks. TxtClient then parses the body without
+        // making any further network call.
+        $robots = Http::get($base.'/robots.txt');
+
+        $client = new TxtClient($base, $robots->status(), (string) $robots->body());
 
         if (! $client->userAgent('Googlebot')->isAllowed($url)) {
             $this->failureReason = __('failed.configuration.robots.disallowed');

--- a/tests/Checks/Configuration/RobotsCheckTest.php
+++ b/tests/Checks/Configuration/RobotsCheckTest.php
@@ -4,13 +4,38 @@ use Backstage\Seo\Checks\Configuration\RobotsCheck;
 use Illuminate\Support\Facades\Http;
 use Symfony\Component\DomCrawler\Crawler;
 
-it('can perform the robots check', function () {
+it('passes when Googlebot is allowed to index the page', function () {
     $check = new RobotsCheck;
+    $check->url = 'https://backstagephp.com';
 
     Http::fake([
-        'backstagephp.com/robots.txt' => Http::response('User-agent: Googlebot
-            Disallow: /admin', 200),
+        'backstagephp.com/robots.txt' => Http::response("User-agent: Googlebot\nDisallow: /admin", 200),
+        '*' => Http::response('<html></html>', 200),
     ]);
 
-    $this->assertTrue($check->check(Http::get('https://backstagephp.com'), new Crawler));
+    expect($check->check(Http::get('https://backstagephp.com'), new Crawler))->toBeTrue();
+});
+
+it('fails when Googlebot is fully disallowed', function () {
+    $check = new RobotsCheck;
+    $check->url = 'https://backstagephp.com';
+
+    Http::fake([
+        'backstagephp.com/robots.txt' => Http::response("User-agent: Googlebot\nDisallow: /", 200),
+        '*' => Http::response('<html></html>', 200),
+    ]);
+
+    expect($check->check(Http::get('https://backstagephp.com'), new Crawler))->toBeFalse();
+});
+
+it('passes when no robots.txt is present', function () {
+    $check = new RobotsCheck;
+    $check->url = 'https://backstagephp.com';
+
+    Http::fake([
+        'backstagephp.com/robots.txt' => Http::response('Not found', 404),
+        '*' => Http::response('<html></html>', 200),
+    ]);
+
+    expect($check->check(Http::get('https://backstagephp.com'), new Crawler))->toBeTrue();
 });

--- a/tests/Commands/QueuedScanTest.php
+++ b/tests/Commands/QueuedScanTest.php
@@ -6,6 +6,7 @@ use Backstage\Seo\Models\SeoScan as SeoScanModel;
 use Backstage\Seo\Tests\Support\Product;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Schema;
 
 beforeEach(function () {
@@ -15,6 +16,11 @@ beforeEach(function () {
     config(['seo.check_routes' => false]);
     config(['seo.models' => [Product::class]]);
     $this->loadMigrationsFrom(__DIR__.'/../../database/migrations');
+
+    // The non-queued run scans inline, so stub HTTP to keep it off the network.
+    Http::fake([
+        '*' => Http::response('<html><head><title>Test</title></head><body><h1>Test</h1></body></html>'),
+    ]);
 
     Schema::create('products', function ($table) {
         $table->bigIncrements('id');

--- a/tests/SeoTest.php
+++ b/tests/SeoTest.php
@@ -1,6 +1,18 @@
 <?php
 
 use Backstage\Seo\Checks\Content\MultipleHeadingCheck;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    // Stub every request so the scan runs against a known page instead of
+    // hitting the live site, which made these tests flaky in CI.
+    Http::fake([
+        '*' => Http::response(
+            '<html><head><title>Test page</title></head><body><h1>Test</h1><p>Content</p></body></html>',
+            200
+        ),
+    ]);
+});
 
 it('can run the SEO check for a single URL', function () {
     $this->artisan('seo:scan-url', ['url' => 'https://backstagephp.com'])

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Backstage\Seo\Tests;
 
 use Backstage\Seo\SeoServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Http;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
@@ -17,6 +18,11 @@ class TestCase extends Orchestra
         Factory::guessFactoryNamesUsing(
             fn (string $modelName) => 'Backstage\\Seo\\Database\\Factories\\'.class_basename($modelName).'Factory'
         );
+
+        // Fail fast and loud if a test makes an HTTP request it didn't fake,
+        // instead of silently hitting the live network and timing out
+        // intermittently in CI. Tests that need HTTP must Http::fake() it.
+        Http::preventStrayRequests();
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
## Summary

`run-tests` on `main` failed intermittently because several tests hit the **live network** (`backstagephp.com`, `example.com`) instead of faking HTTP. They passed only when those sites were reachable and fast, and failed on 30s `cURL error 28` timeouts when they weren't — which is what broke CI. This makes the whole suite hermetic.

## Failures fixed

1. **`RobotsCheck` / `RobotsCheckTest`** — `RobotsCheck` used vipnytt's `UriClient`, which fetches `robots.txt` over the real network (bypassing Laravel's HTTP client, so `Http::fake()` never applied) and read the URL only from `transferStats`. It now fetches via the fakeable Laravel `Http` client and parses the body with `TxtClient` (no extra network call), deriving the base URL from `$this->url` with a `transferStats` fallback — matching `AiCrawlerCheck`. It also now honours the `robots.txt` status code (404 → "nothing disallowed"). Test rewritten + extended (allowed / disallowed / missing cases).
2. **`SeoTest`** — ran the scan command synchronously against the real `backstagephp.com` with no fake. Now stubs HTTP.
3. **`QueuedScanTest`** — the non-queued case scanned `example.com` for real. Now stubs HTTP.

## Safeguard

Added `Http::preventStrayRequests()` to the base `TestCase`. Any future test that makes an unfaked request now fails **fast and loud** (instantly) instead of silently hitting the network and timing out randomly in CI. This guard is what surfaced the hidden `QueuedScanTest` leak.

## Verification

Local suite: **163 passed, 3 skipped** (the 3 are the intentional DNS/image-size/TTFB integration skips). Runtime dropped from ~9s to ~2s now that nothing waits on the network. Pint + PHPStan clean.
