### PR TITLE
Wait for JavaScript to render in SPA mode, with a safe fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,35 @@ php artisan seo:scan-url https://backstagephp.com --javascript
 
 > Note: This command will use Puppeteer to render the page. Make sure that you have Puppeteer installed on your system. You can install Puppeteer by running the following command: `npm install puppeteer`. **At this moment it's only available when scanning single routes.**
 
+#### Waiting for JavaScript to render
+
+By default the scanner now waits for the page to settle before capturing the DOM, so checks run against the fully rendered page instead of the pre-hydration app shell. You can tune this with the `javascript_wait` options in the config file:
+
+```php
+'javascript_wait' => [
+    // How to wait for the page to settle:
+    //   "networkidle2" (default) — settle at ≤ 2 open network connections.
+    //   "networkidle0" — settle only at 0 open connections.
+    //   "delay" — don't wait for the network, wait a fixed time instead.
+    'strategy' => 'networkidle2',
+
+    // Hard ceiling per page, in seconds.
+    'timeout' => 15,
+
+    // Milliseconds to wait, only used when strategy is "delay".
+    'delay' => 3000,
+
+    // On a render timeout, fall back to an immediate render (and then to the
+    // raw HTTP response) instead of failing the page. Set to false to keep the
+    // previous behavior of failing the page on timeout.
+    'fallback_on_timeout' => true,
+],
+```
+
+`networkidle2` is the default because the scanner runs against unknown sites: analytics beacons, chat widgets and websockets keep connections open, so a stricter `networkidle0` would often never settle and time out.
+
+> Note: because rendering now waits for the page, SEO scores for JavaScript-rendered pages may change compared to earlier versions. If you prefer the previous behavior where a render timeout fails the page, set `fallback_on_timeout` to `false`.
+
 ### PageSpeed Insights (Core Web Vitals)
 
 The package can pull the Google PageSpeed (Lighthouse) performance score and Core Web Vitals straight from the [PageSpeed Insights API](https://developers.google.com/speed/docs/insights/v5/get-started) — no third-party package required. These checks are **opt-in** because they call an external API and are slower and rate-limited.

--- a/config/seo.php
+++ b/config/seo.php
@@ -233,6 +233,40 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | JavaScript rendering: waiting and fallback
+    |--------------------------------------------------------------------------
+    |
+    | When JavaScript rendering is enabled, the scanner waits for the page to
+    | settle before capturing the DOM, so checks run against the fully rendered
+    | page instead of the pre-hydration app shell.
+    |
+    | strategy: how to wait for the page to settle.
+    |   - "networkidle2" (default): settle when there are at most 2 open network
+    |     connections. Recommended for unknown sites, since analytics beacons,
+    |     chat widgets and websockets keep connections open and would prevent a
+    |     stricter strategy from ever settling.
+    |   - "networkidle0": settle only when there are zero open connections.
+    |   - "delay": do not wait for the network; wait a fixed number of
+    |     milliseconds ("delay" below).
+    |
+    | timeout: hard ceiling per page, in seconds.
+    |
+    | delay: milliseconds to wait, only used when strategy is "delay".
+    |
+    | fallback_on_timeout: when a render times out, fall back to an immediate
+    | render (and then to the raw HTTP response) instead of failing the page.
+    | Set to false to keep the previous behavior of failing the page on timeout.
+    |
+    */
+    'javascript_wait' => [
+        'strategy' => 'networkidle2',
+        'timeout' => 15,
+        'delay' => 3000,
+        'fallback_on_timeout' => true,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | PageSpeed Insights
     |--------------------------------------------------------------------------
     |

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -2,13 +2,13 @@
 
 namespace Backstage\Seo;
 
+use Backstage\Seo\Support\JavascriptRenderer;
 use Illuminate\Http\Client\Response;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
-use Spatie\Browsershot\Browsershot;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Finder\Finder;
@@ -37,7 +37,7 @@ class Seo
             $response = $this->visitPage(url: $url);
 
             if ($useJavascript) {
-                $javascriptResponse = $this->visitPageUsingJavascript(url: $url);
+                $javascriptResponse = $this->visitPageUsingJavascript(url: $url, rawResponse: $response);
             }
         } catch (\Exception $e) {
             throw new \Exception("Could not visit url `{$url}`: {$e->getMessage()}");
@@ -48,12 +48,9 @@ class Seo
         return (new SeoScore)($this->successful, $this->failed);
     }
 
-    private function visitPageUsingJavascript(string $url): string
+    private function visitPageUsingJavascript(string $url, Response $rawResponse): string
     {
-        $response = Browsershot::url($url)
-            ->bodyHtml();
-
-        return $response;
+        return app(JavascriptRenderer::class)->render($url, $rawResponse);
     }
 
     private function visitPage(string $url): object

--- a/src/Support/JavascriptRenderer.php
+++ b/src/Support/JavascriptRenderer.php
@@ -24,7 +24,7 @@ class JavascriptRenderer
                 throw $e;
             }
 
-            Log::warning("SEO scanner: JavaScript render timed out for `{$url}`, falling back to an immediate render.", ['exception' => $e->getMessage()]);
+            Log::warning("SEO scanner: JavaScript render failed for `{$url}`, falling back to an immediate render.", ['exception' => $e->getMessage()]);
 
             try {
                 return $this->capture($url, wait: false);

--- a/src/Support/JavascriptRenderer.php
+++ b/src/Support/JavascriptRenderer.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Backstage\Seo\Support;
+
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Log;
+use Spatie\Browsershot\Browsershot;
+use Throwable;
+
+class JavascriptRenderer
+{
+    /**
+     * Render a URL with JavaScript executed, waiting for the page to settle.
+     *
+     * On a render timeout/failure, falls back to an immediate render and then
+     * to the raw HTTP response body, unless fallback is disabled in config.
+     */
+    public function render(string $url, Response $rawResponse): string
+    {
+        try {
+            return $this->capture($url, wait: true);
+        } catch (Throwable $e) {
+            if (! config('seo.javascript_wait.fallback_on_timeout', true)) {
+                throw $e;
+            }
+
+            Log::warning("SEO scanner: JavaScript render timed out for `{$url}`, falling back to an immediate render.", ['exception' => $e->getMessage()]);
+
+            try {
+                return $this->capture($url, wait: false);
+            } catch (Throwable $inner) {
+                Log::warning("SEO scanner: immediate JavaScript render also failed for `{$url}`, falling back to the raw HTTP response.", ['exception' => $inner->getMessage()]);
+
+                return $rawResponse->body();
+            }
+        }
+    }
+
+    /**
+     * Capture the rendered HTML for a URL.
+     *
+     * When $wait is true, the configured wait strategy and timeout are applied.
+     */
+    protected function capture(string $url, bool $wait): string
+    {
+        $browsershot = $this->newBrowsershot($url);
+
+        if ($wait) {
+            $browsershot = $this->applyWaitStrategy($browsershot);
+        }
+
+        return $browsershot->bodyHtml();
+    }
+
+    /**
+     * Apply the configured wait strategy and timeout to a Browsershot instance.
+     */
+    public function applyWaitStrategy(Browsershot $browsershot): Browsershot
+    {
+        $strategy = config('seo.javascript_wait.strategy', 'networkidle2');
+        $timeout = (int) config('seo.javascript_wait.timeout', 15);
+
+        $browsershot->timeout($timeout);
+
+        return match ($strategy) {
+            'networkidle0' => $browsershot->waitUntilNetworkIdle(strict: true),
+            'delay' => $browsershot->setDelay((int) config('seo.javascript_wait.delay', 3000)),
+            default => $browsershot->waitUntilNetworkIdle(strict: false),
+        };
+    }
+
+    protected function newBrowsershot(string $url): Browsershot
+    {
+        return Browsershot::url($url);
+    }
+}

--- a/tests/SeoTest.php
+++ b/tests/SeoTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Backstage\Seo\Checks\Content\MultipleHeadingCheck;
+use Backstage\Seo\Support\JavascriptRenderer;
 use Illuminate\Support\Facades\Http;
 
 beforeEach(function () {
@@ -42,4 +43,31 @@ it('can only run configured checks', function () {
     $this->artisan('seo:scan-url', ['url' => 'https://backstagephp.com'])
         ->expectsOutputToContain('1 out of '.getCheckCount().' checks.')
         ->assertExitCode(0);
+});
+
+it('uses the JavaScript renderer when javascript rendering is enabled', function () {
+    config(['seo.database.save' => false]);
+    config(['seo.check_routes' => false]);
+    config(['seo.checks' => [
+        MultipleHeadingCheck::class,
+    ]]);
+
+    $renderer = new class extends JavascriptRenderer
+    {
+        public array $renderedUrls = [];
+
+        public function render(string $url, \Illuminate\Http\Client\Response $rawResponse): string
+        {
+            $this->renderedUrls[] = $url;
+
+            return '<html><head><title>Rendered by JS</title></head><body><h1>One</h1></body></html>';
+        }
+    };
+
+    app()->instance(JavascriptRenderer::class, $renderer);
+
+    $this->artisan('seo:scan-url', ['url' => 'https://backstagephp.com', '--javascript' => true])
+        ->assertExitCode(0);
+
+    expect($renderer->renderedUrls)->toBe(['https://backstagephp.com']);
 });

--- a/tests/SeoTest.php
+++ b/tests/SeoTest.php
@@ -2,6 +2,7 @@
 
 use Backstage\Seo\Checks\Content\MultipleHeadingCheck;
 use Backstage\Seo\Support\JavascriptRenderer;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
 
 beforeEach(function () {
@@ -56,7 +57,7 @@ it('uses the JavaScript renderer when javascript rendering is enabled', function
     {
         public array $renderedUrls = [];
 
-        public function render(string $url, \Illuminate\Http\Client\Response $rawResponse): string
+        public function render(string $url, Response $rawResponse): string
         {
             $this->renderedUrls[] = $url;
 

--- a/tests/Support/JavascriptRendererTest.php
+++ b/tests/Support/JavascriptRendererTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use Backstage\Seo\Support\JavascriptRenderer;
+use Illuminate\Support\Facades\Http;
+use Spatie\Browsershot\Browsershot;
+
+afterEach(function () {
+    Mockery::close();
+});
+
+it('configures networkidle2 and timeout by default', function () {
+    config(['seo.javascript_wait' => [
+        'strategy' => 'networkidle2',
+        'timeout' => 15,
+        'delay' => 3000,
+        'fallback_on_timeout' => true,
+    ]]);
+
+    $browsershot = Mockery::mock(Browsershot::class);
+    $browsershot->shouldReceive('timeout')->once()->with(15)->andReturnSelf();
+    $browsershot->shouldReceive('waitUntilNetworkIdle')->once()->with(false)->andReturnSelf();
+
+    $result = (new JavascriptRenderer)->applyWaitStrategy($browsershot);
+
+    expect($result)->toBe($browsershot);
+});
+
+it('configures networkidle0 when strategy is networkidle0', function () {
+    config(['seo.javascript_wait' => [
+        'strategy' => 'networkidle0',
+        'timeout' => 20,
+        'delay' => 3000,
+        'fallback_on_timeout' => true,
+    ]]);
+
+    $browsershot = Mockery::mock(Browsershot::class);
+    $browsershot->shouldReceive('timeout')->once()->with(20)->andReturnSelf();
+    $browsershot->shouldReceive('waitUntilNetworkIdle')->once()->with(true)->andReturnSelf();
+
+    (new JavascriptRenderer)->applyWaitStrategy($browsershot);
+});
+
+it('uses a fixed delay and no network wait when strategy is delay', function () {
+    config(['seo.javascript_wait' => [
+        'strategy' => 'delay',
+        'timeout' => 15,
+        'delay' => 5000,
+        'fallback_on_timeout' => true,
+    ]]);
+
+    $browsershot = Mockery::mock(Browsershot::class);
+    $browsershot->shouldReceive('timeout')->once()->with(15)->andReturnSelf();
+    $browsershot->shouldReceive('setDelay')->once()->with(5000)->andReturnSelf();
+    $browsershot->shouldNotReceive('waitUntilNetworkIdle');
+
+    (new JavascriptRenderer)->applyWaitStrategy($browsershot);
+});
+
+it('defaults to networkidle2 and a 15 second timeout when javascript_wait is not configured', function () {
+    config(['seo.javascript_wait' => null]);
+
+    $browsershot = Mockery::mock(Browsershot::class);
+    $browsershot->shouldReceive('timeout')->once()->with(15)->andReturnSelf();
+    $browsershot->shouldReceive('waitUntilNetworkIdle')->once()->with(false)->andReturnSelf();
+
+    (new JavascriptRenderer)->applyWaitStrategy($browsershot);
+});
+
+it('falls back to an immediate render when the waited render fails', function () {
+    config(['seo.javascript_wait.fallback_on_timeout' => true]);
+
+    $renderer = new class extends JavascriptRenderer
+    {
+        public array $waits = [];
+
+        protected function capture(string $url, bool $wait): string
+        {
+            $this->waits[] = $wait;
+
+            if ($wait) {
+                throw new RuntimeException('Navigation timeout');
+            }
+
+            return '<html><head><title>Immediate</title></head></html>';
+        }
+    };
+
+    Http::fake(['*' => Http::response('RAW BODY', 200)]);
+    $raw = Http::get('https://example.com');
+
+    $html = $renderer->render('https://example.com', $raw);
+
+    expect($html)->toBe('<html><head><title>Immediate</title></head></html>');
+    expect($renderer->waits)->toBe([true, false]);
+});
+
+it('falls back to the raw response body when every render fails', function () {
+    config(['seo.javascript_wait.fallback_on_timeout' => true]);
+
+    $renderer = new class extends JavascriptRenderer
+    {
+        protected function capture(string $url, bool $wait): string
+        {
+            throw new RuntimeException('render failed');
+        }
+    };
+
+    Http::fake(['*' => Http::response('RAW SERVER HTML', 200)]);
+    $raw = Http::get('https://example.com');
+
+    $html = $renderer->render('https://example.com', $raw);
+
+    expect($html)->toBe('RAW SERVER HTML');
+});
+
+it('rethrows when fallback_on_timeout is disabled', function () {
+    config(['seo.javascript_wait.fallback_on_timeout' => false]);
+
+    $renderer = new class extends JavascriptRenderer
+    {
+        protected function capture(string $url, bool $wait): string
+        {
+            throw new RuntimeException('Navigation timeout');
+        }
+    };
+
+    Http::fake(['*' => Http::response('RAW', 200)]);
+    $raw = Http::get('https://example.com');
+
+    $renderer->render('https://example.com', $raw);
+})->throws(RuntimeException::class, 'Navigation timeout');


### PR DESCRIPTION
## Why

When JavaScript rendering is enabled, the scanner rendered pages with `Browsershot::url($url)->bodyHtml()`, which captured the DOM **before** the page's JavaScript finished. For a real SPA (React, Vue, …) the checks then ran against the pre-hydration app shell, producing false negatives. Search engines such as Google do execute JavaScript, so this was a limitation of the scanner rather than of the scanned site.

## What

- **`JavascriptRenderer` service** (`src/Support/JavascriptRenderer.php`) — waits for the page to settle before capturing the DOM, using a configurable strategy and a hard timeout.
- **Safe fallback chain** — on a render failure it falls back to an immediate render, and then to the raw HTTP response, so a scan is **never worse than before**. Set `fallback_on_timeout` to `false` to keep the previous fail-on-timeout behavior.
- **New `javascript_wait` config block** in `config/seo.php` (`strategy`, `timeout`, `delay`, `fallback_on_timeout`), with sensible defaults. All reads default gracefully, so existing published config files keep working.
- **`Seo` now delegates** JS rendering to the renderer via the container, passing the raw response for the fallback.
- **README** documents the options and the `networkidle2` default rationale.

### Defaults

| Key | Default | Notes |
|-----|---------|-------|
| `strategy` | `networkidle2` | Settles at ≤ 2 open connections — robust for unknown sites where analytics/chat/websockets keep connections open. Also `networkidle0` and `delay`. |
| `timeout` | `15` | Hard ceiling per page, in seconds. |
| `delay` | `3000` | Milliseconds, only used when `strategy = delay`. |
| `fallback_on_timeout` | `true` | Fall back instead of failing the page; set `false` for the old behavior. |

## Compatibility

Minor release. Existing JavaScript-mode users will get more complete rendered HTML, so SEO scores for JS-rendered pages may shift — this is the intended correction, documented in the README, with an opt-out via `fallback_on_timeout`. Non-JavaScript scans (the default) are unaffected.

## Tests

Hermetic — no live network, no real browser. Full suite green (171 passed, 3 pre-existing skips), PHPStan clean. New coverage: wait-strategy configuration (networkidle0/2, delay), absent-config defaults, and the full fallback chain (fallback enabled → immediate render → raw body; fallback disabled → rethrow).