### PR TITLE
feat: scan external domains with URL discovery and model morphing

### DIFF
--- a/config/seo.php
+++ b/config/seo.php
@@ -102,6 +102,22 @@ return [
         'vapor-ui/*',
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Domain crawling (seo:scan-domain / Seo::scanDomain())
+    |--------------------------------------------------------------------------
+    |
+    | When scanning an external domain, page URLs are discovered through the
+    | domain's XML sitemap(s) when available, and otherwise by crawling
+    | same-host links starting at the homepage. The options below bound that
+    | discovery. The max_depth option only applies to the crawl fallback.
+    |
+    */
+    'crawl' => [
+        'max_pages' => 50,
+        'max_depth' => 2,
+    ],
+
     'throttle' => [
         'enabled' => false,
         'requests_per_minute' => null,
@@ -154,7 +170,7 @@ return [
     |
     */
     'database' => [
-        'connection' => 'mysql',
+        'connection' => env('DB_CONNECTION', 'mysql'),
         'save' => true,
         'prune' => [
             'older_than_days' => 30,

--- a/database/migrations/add_url_and_model_to_seo_scans_table.php
+++ b/database/migrations/add_url_and_model_to_seo_scans_table.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (! Schema::hasTable('seo_scans')) {
+            return;
+        }
+
+        Schema::table('seo_scans', function (Blueprint $table) {
+            if (! Schema::hasColumn('seo_scans', 'url')) {
+                $table->string('url')->nullable()->after('id');
+            }
+
+            if (! Schema::hasColumn('seo_scans', 'model_type')) {
+                // String-based morph columns so subject models with integer,
+                // uuid or ulid keys are all supported.
+                $table->string('model_type')->nullable();
+                $table->string('model_id')->nullable();
+                $table->index(['model_type', 'model_id']);
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if (! Schema::hasTable('seo_scans')) {
+            return;
+        }
+
+        Schema::table('seo_scans', function (Blueprint $table) {
+            if (Schema::hasColumn('seo_scans', 'model_type')) {
+                $table->dropIndex(['model_type', 'model_id']);
+                $table->dropColumn(['model_type', 'model_id']);
+            }
+
+            if (Schema::hasColumn('seo_scans', 'url')) {
+                $table->dropColumn('url');
+            }
+        });
+    }
+};

--- a/database/migrations/change_model_id_to_string_on_seo_scores_table.php
+++ b/database/migrations/change_model_id_to_string_on_seo_scores_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Widen the morph id column from an unsigned big integer to a string so
+     * subject models with integer, uuid or ulid keys are all supported.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (! Schema::hasTable('seo_scores') || $this->modelIdIsString()) {
+            return;
+        }
+
+        Schema::table('seo_scores', function (Blueprint $table) {
+            $table->string('model_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if (! Schema::hasTable('seo_scores') || ! $this->modelIdIsString()) {
+            return;
+        }
+
+        Schema::table('seo_scores', function (Blueprint $table) {
+            $table->unsignedBigInteger('model_id')->nullable()->change();
+        });
+    }
+
+    private function modelIdIsString(): bool
+    {
+        return in_array(Schema::getColumnType('seo_scores', 'model_id'), ['varchar', 'character varying', 'string', 'text']);
+    }
+};

--- a/database/migrations/create_seo_scans_table.php
+++ b/database/migrations/create_seo_scans_table.php
@@ -15,6 +15,13 @@ return new class extends Migration
     {
         Schema::create('seo_scans', function (Blueprint $table) {
             $table->bigIncrements('id');
+            $table->string('url')->nullable();
+
+            // String-based morph columns so subject models with integer,
+            // uuid or ulid keys are all supported.
+            $table->string('model_type')->nullable();
+            $table->string('model_id')->nullable();
+            $table->index(['model_type', 'model_id']);
             $table->unsignedInteger('pages')->nullable();
             $table->unsignedInteger('total_checks')->nullable();
             $table->json('failed_checks')->nullable();

--- a/database/migrations/create_seo_score_table.php
+++ b/database/migrations/create_seo_score_table.php
@@ -17,7 +17,11 @@ return new class extends Migration
             $table->bigIncrements('id');
             $table->unsignedBigInteger('seo_scan_id');
             $table->string('url');
-            $table->nullableMorphs('model', 'model');
+            // String-based morph columns so subject models with integer,
+            // uuid or ulid keys are all supported.
+            $table->string('model_type')->nullable();
+            $table->string('model_id')->nullable();
+            $table->index(['model_type', 'model_id'], 'model');
             $table->integer('score');
             $table->json('checks');
             $table->timestamps();

--- a/src/Commands/SeoScanDomain.php
+++ b/src/Commands/SeoScanDomain.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Backstage\Seo\Commands;
+
+use Backstage\Seo\Services\DomainScanner;
+use Illuminate\Console\Command;
+
+class SeoScanDomain extends Command
+{
+    public $signature = 'seo:scan-domain
+        {domain : The domain to scan, e.g. example.com}
+        {--queue : Dispatch the page scans as batched queue jobs instead of running them synchronously}
+        {--max-pages= : Maximum number of pages to scan, defaults to seo.crawl.max_pages}
+        {--javascript : Render pages with javascript before running the checks}
+        {--format=console : The output format (console or json)}';
+
+    public $description = 'Scan the SEO score of an external domain';
+
+    public function handle(DomainScanner $scanner): int
+    {
+        $json = $this->option('format') === 'json';
+
+        if (! $json) {
+            $this->info('Please wait while we scan '.$this->argument('domain').'...');
+            $this->line('');
+        }
+
+        try {
+            $scan = $scanner->scan(
+                domain: $this->argument('domain'),
+                queue: $this->option('queue'),
+                maxPages: $this->option('max-pages') ? (int) $this->option('max-pages') : null,
+                useJavascript: $this->option('javascript') ?: null,
+            );
+        } catch (\InvalidArgumentException $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if ($this->option('queue')) {
+            $this->info('Dispatched scan #'.$scan->id.' for '.$scan->url.' to the queue.');
+
+            return self::SUCCESS;
+        }
+
+        if ($json) {
+            $this->output->writeln(json_encode([
+                'scan_id' => $scan->id,
+                'url' => $scan->url,
+                'pages' => $scan->pages,
+                'failed_checks' => $scan->failed_checks,
+                'average_score' => (int) round($scan->scores()->avg('score') ?? 0),
+                'time' => $scan->time,
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return self::SUCCESS;
+        }
+
+        $this->info('Scanned '.$scan->pages.' page(s) on '.$scan->url.' in '.round((float) $scan->time, 2).'s.');
+        $this->line('Average score: '.(int) round($scan->scores()->avg('score') ?? 0).'/100');
+
+        if (! empty($scan->failed_checks)) {
+            $this->line('');
+            $this->line('<fg=red>Failed checks across the scanned pages:</>');
+
+            foreach ($scan->failed_checks as $check) {
+                $this->line('<fg=red>✘ '.class_basename($check).'</>');
+            }
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Facades/Seo.php
+++ b/src/Facades/Seo.php
@@ -5,6 +5,9 @@ namespace Backstage\Seo\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
+ * @method static \Backstage\Seo\SeoScore check(string $url, ?\Symfony\Component\Console\Helper\ProgressBar $progress = null, bool $useJavascript = false)
+ * @method static \Backstage\Seo\Models\SeoScan scanDomain(string $domain, ?\Illuminate\Database\Eloquent\Model $subject = null, bool $queue = false, ?int $maxPages = null, ?bool $useJavascript = null)
+ *
  * @see \Backstage\Seo\Seo
  */
 class Seo extends Facade

--- a/src/Jobs/ScanChunk.php
+++ b/src/Jobs/ScanChunk.php
@@ -80,8 +80,10 @@ class ScanChunk implements ShouldQueue
             return;
         }
 
+        $subject = $scan->model;
+
         foreach ($this->urls as $url) {
-            $this->scanSafely($runner, $scan, $url);
+            $this->scanSafely($runner, $scan, $url, $subject);
         }
 
         if ($this->model && ! empty($this->ids)) {

--- a/src/Models/SeoScan.php
+++ b/src/Models/SeoScan.php
@@ -6,10 +6,14 @@ use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Carbon;
 
 /**
  * @property int $id
+ * @property string|null $url
+ * @property string|null $model_type
+ * @property int|string|null $model_id
  * @property int $pages
  * @property int $total_checks
  * @property array $failed_checks
@@ -27,6 +31,8 @@ class SeoScan extends Model
 
     protected $casts = [
         'failed_checks' => 'array',
+        'started_at' => 'datetime',
+        'finished_at' => 'datetime',
     ];
 
     public function __construct(array $attributes = [])
@@ -43,6 +49,14 @@ class SeoScan extends Model
     public function scores(): HasMany
     {
         return $this->hasMany(SeoScore::class);
+    }
+
+    /**
+     * The application model this scan was run for (e.g. a Domain or Site).
+     */
+    public function model(): MorphTo
+    {
+        return $this->morphTo();
     }
 
     public function prunable(): Builder

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -2,7 +2,10 @@
 
 namespace Backstage\Seo;
 
+use Backstage\Seo\Models\SeoScan as SeoScanModel;
+use Backstage\Seo\Services\DomainScanner;
 use Backstage\Seo\Support\JavascriptRenderer;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Client\Response;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Arr;
@@ -46,6 +49,20 @@ class Seo
         $this->runChecks(response: $response, javascriptResponse: $javascriptResponse ?? null);
 
         return (new SeoScore)($this->successful, $this->failed);
+    }
+
+    /**
+     * Scan every discoverable page of an external domain, optionally
+     * relating the scan and its scores to an application model.
+     */
+    public function scanDomain(
+        string $domain,
+        ?Model $subject = null,
+        bool $queue = false,
+        ?int $maxPages = null,
+        ?bool $useJavascript = null,
+    ): SeoScanModel {
+        return app(DomainScanner::class)->scan($domain, $subject, $queue, $maxPages, $useJavascript);
     }
 
     private function visitPageUsingJavascript(string $url, Response $rawResponse): string

--- a/src/SeoServiceProvider.php
+++ b/src/SeoServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Backstage\Seo;
 
 use Backstage\Seo\Commands\SeoScan;
+use Backstage\Seo\Commands\SeoScanDomain;
 use Backstage\Seo\Commands\SeoScanUrl;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Support\Facades\RateLimiter;
@@ -33,9 +34,15 @@ class SeoServiceProvider extends PackageServiceProvider
             ->hasConfigFile()
             ->hasViews()
             ->hasTranslations()
-            ->hasMigrations(['create_seo_scans_table', 'create_seo_score_table'])
+            ->hasMigrations([
+                'create_seo_scans_table',
+                'create_seo_score_table',
+                'add_url_and_model_to_seo_scans_table',
+                'change_model_id_to_string_on_seo_scores_table',
+            ])
             ->hasCommands([
                 SeoScan::class,
+                SeoScanDomain::class,
                 SeoScanUrl::class,
             ]);
 

--- a/src/Services/DomainScanner.php
+++ b/src/Services/DomainScanner.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Backstage\Seo\Services;
+
+use Backstage\Seo\Jobs\ScanChunk;
+use Backstage\Seo\Models\SeoScan as SeoScanModel;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Bus;
+
+class DomainScanner
+{
+    public function __construct(
+        protected UrlDiscoverer $discoverer,
+        protected PageScanRunner $runner,
+        protected ScanFinalizer $finalizer,
+    ) {}
+
+    /**
+     * Scan every discoverable page of an external domain.
+     *
+     * The scan record (and each of its scores) is morphed to the given
+     * subject model, so applications can relate scans to their own models
+     * such as a Domain or Site. When $queue is true the page scans are
+     * dispatched as a job batch and the returned scan finishes asynchronously.
+     */
+    public function scan(
+        string $domain,
+        ?Model $subject = null,
+        bool $queue = false,
+        ?int $maxPages = null,
+        ?bool $useJavascript = null,
+    ): SeoScanModel {
+        $baseUrl = $this->discoverer->normalizeBaseUrl($domain);
+        $urls = $this->discoverer->discover($domain, $maxPages);
+        $useJavascript = $useJavascript ?? (bool) config('seo.javascript');
+
+        $scan = SeoScanModel::create([
+            'url' => $baseUrl,
+            'model_type' => $subject?->getMorphClass(),
+            'model_id' => $subject?->getKey(),
+            'total_checks' => getCheckCount(),
+            'started_at' => now(),
+        ]);
+
+        if ($queue) {
+            $this->dispatchBatch($scan, $urls);
+
+            return $scan;
+        }
+
+        $urls->each(function (string $url) use ($scan, $subject, $useJavascript) {
+            try {
+                $this->runner->scan($scan, $url, $subject, $useJavascript);
+            } catch (\Throwable $e) {
+                report($e);
+            }
+        });
+
+        $this->finalizer->finalize($scan);
+
+        return $scan->refresh();
+    }
+
+    /**
+     * @param  Collection<int, string>  $urls
+     */
+    private function dispatchBatch(SeoScanModel $scan, Collection $urls): void
+    {
+        $scanId = $scan->id;
+
+        $jobs = $urls->chunk((int) config('seo.chunk_size', 100))
+            ->map(fn (Collection $chunk) => new ScanChunk(scanId: $scanId, urls: $chunk->values()->all()))
+            ->all();
+
+        Bus::batch($jobs)
+            ->name('SEO scan #'.$scanId.' ('.$scan->url.')')
+            ->onQueue(config('seo.queue'))
+            ->finally(function () use ($scanId) {
+                if ($scan = SeoScanModel::find($scanId)) {
+                    app(ScanFinalizer::class)->finalize($scan);
+                }
+            })
+            ->dispatch();
+    }
+}

--- a/src/Services/UrlDiscoverer.php
+++ b/src/Services/UrlDiscoverer.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace Backstage\Seo\Services;
+
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use Symfony\Component\DomCrawler\Crawler;
+
+class UrlDiscoverer
+{
+    /**
+     * File extensions that never point to scannable HTML pages.
+     */
+    private const EXCLUDED_EXTENSIONS = [
+        'png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'svg', 'ico',
+        'css', 'js', 'json', 'xml', 'txt', 'pdf', 'zip', 'gz',
+        'mp3', 'mp4', 'webm', 'woff', 'woff2', 'ttf', 'eot',
+    ];
+
+    /**
+     * Discover the scannable page URLs of an external domain.
+     *
+     * URLs are taken from the domain's XML sitemap(s) when available (found
+     * via robots.txt or the /sitemap.xml convention) and otherwise gathered
+     * by a bounded same-host crawl starting at the homepage.
+     *
+     * @return Collection<int, string>
+     */
+    public function discover(string $domain, ?int $maxPages = null): Collection
+    {
+        $baseUrl = $this->normalizeBaseUrl($domain);
+        $maxPages = $maxPages ?? (int) config('seo.crawl.max_pages', 50);
+
+        $urls = $this->discoverFromSitemaps($baseUrl, $maxPages);
+
+        if ($urls->isEmpty()) {
+            $urls = $this->discoverByCrawling($baseUrl, $maxPages);
+        }
+
+        return $urls->when($urls->isEmpty(), fn () => collect([$baseUrl]))
+            ->unique()
+            ->take($maxPages)
+            ->values();
+    }
+
+    /**
+     * Turn user input like "example.com" or "https://example.com/path" into
+     * a scheme-qualified base URL without path, query or fragment.
+     */
+    public function normalizeBaseUrl(string $domain): string
+    {
+        $domain = trim($domain);
+
+        if (! preg_match('#^https?://#i', $domain)) {
+            $domain = 'https://'.$domain;
+        }
+
+        $parts = parse_url($domain);
+
+        if (empty($parts['host'])) {
+            throw new \InvalidArgumentException("Could not determine a host from `{$domain}`.");
+        }
+
+        $scheme = $parts['scheme'] ?? 'https';
+
+        return $scheme.'://'.$parts['host'].(isset($parts['port']) ? ':'.$parts['port'] : '');
+    }
+
+    /**
+     * @return Collection<int, string>
+     */
+    private function discoverFromSitemaps(string $baseUrl, int $maxPages): Collection
+    {
+        $queue = $this->sitemapUrlsFromRobots($baseUrl) ?: [$baseUrl.'/sitemap.xml'];
+        $urls = collect();
+        $fetched = 0;
+
+        while (! empty($queue) && $urls->count() < $maxPages && $fetched < 50) {
+            $sitemapUrl = array_shift($queue);
+            $fetched++;
+
+            $response = $this->fetch($sitemapUrl);
+
+            if (! $response?->successful()) {
+                continue;
+            }
+
+            $body = (string) $response->body();
+            $locations = $this->extractLocations($body);
+
+            if (preg_match('/<\s*sitemapindex[\s>]/i', $body)) {
+                $queue = array_merge($queue, $locations);
+
+                continue;
+            }
+
+            $urls = $urls->merge(
+                collect($locations)->filter(fn (string $url) => $this->isScannableUrl($url, $baseUrl))
+            );
+        }
+
+        return $urls;
+    }
+
+    /**
+     * Breadth-first crawl of same-host links, used when no sitemap exists.
+     *
+     * @return Collection<int, string>
+     */
+    private function discoverByCrawling(string $baseUrl, int $maxPages): Collection
+    {
+        $maxDepth = (int) config('seo.crawl.max_depth', 2);
+
+        $queue = [[$baseUrl.'/', 0]];
+        $seen = [$baseUrl.'/' => true, $baseUrl => true];
+        $urls = collect();
+
+        while (! empty($queue) && $urls->count() < $maxPages) {
+            [$url, $depth] = array_shift($queue);
+
+            $response = $this->fetch($url);
+
+            if (! $response?->successful() || ! Str::contains(strtolower($response->header('Content-Type')), 'html')) {
+                continue;
+            }
+
+            $urls->push($url);
+
+            if ($depth >= $maxDepth) {
+                continue;
+            }
+
+            foreach ($this->extractLinks($response->body(), $url) as $link) {
+                if (isset($seen[$link]) || ! $this->isScannableUrl($link, $baseUrl)) {
+                    continue;
+                }
+
+                $seen[$link] = true;
+                $queue[] = [$link, $depth + 1];
+            }
+        }
+
+        return $urls;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function sitemapUrlsFromRobots(string $baseUrl): array
+    {
+        $response = $this->fetch($baseUrl.'/robots.txt');
+
+        if (! $response?->successful()) {
+            return [];
+        }
+
+        $sitemaps = [];
+
+        foreach (preg_split('/\r\n|\r|\n/', (string) $response->body()) as $line) {
+            if (preg_match('/^\s*sitemap\s*:\s*(\S+)/i', $line, $matches)) {
+                $sitemaps[] = trim($matches[1]);
+            }
+        }
+
+        return $sitemaps;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function extractLocations(string $xml): array
+    {
+        preg_match_all('/<\s*loc\s*>\s*(.*?)\s*<\s*\/\s*loc\s*>/is', $xml, $matches);
+
+        return array_map(fn (string $loc) => html_entity_decode($loc), $matches[1]);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function extractLinks(string $html, string $pageUrl): array
+    {
+        $links = [];
+
+        foreach ((new Crawler($html, $pageUrl))->filter('a[href]') as $node) {
+            $href = trim((string) $node->getAttribute('href'));
+
+            if ($href === '' || Str::startsWith($href, ['#', 'mailto:', 'tel:', 'javascript:'])) {
+                continue;
+            }
+
+            $links[] = Str::before(addBaseIfRelativeUrl($href, $pageUrl), '#');
+        }
+
+        return array_unique($links);
+    }
+
+    private function isScannableUrl(string $url, string $baseUrl): bool
+    {
+        $host = parse_url($url, PHP_URL_HOST);
+        $baseHost = parse_url($baseUrl, PHP_URL_HOST);
+
+        if (! $host || ! $this->isSameHost($host, $baseHost)) {
+            return false;
+        }
+
+        $extension = strtolower(pathinfo((string) parse_url($url, PHP_URL_PATH), PATHINFO_EXTENSION));
+
+        return $extension === '' || ! in_array($extension, self::EXCLUDED_EXTENSIONS);
+    }
+
+    /**
+     * Treat the www subdomain and the apex domain as the same host, since
+     * sitemaps regularly reference the canonical variant of the two.
+     */
+    private function isSameHost(string $host, string $baseHost): bool
+    {
+        $strip = fn (string $value) => preg_replace('/^www\./', '', strtolower($value));
+
+        return $strip($host) === $strip($baseHost);
+    }
+
+    private function fetch(string $url): ?Response
+    {
+        try {
+            return Http::withOptions((array) config('seo.http.options', []))
+                ->withHeaders((array) config('seo.http.headers', []))
+                ->timeout(30)
+                ->get($url);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/tests/DomainScannerTest.php
+++ b/tests/DomainScannerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use Backstage\Seo\Checks\Content\MultipleHeadingCheck;
+use Backstage\Seo\Jobs\ScanChunk;
+use Backstage\Seo\Services\DomainScanner;
+use Backstage\Seo\Services\PageScanRunner;
+use Backstage\Seo\Tests\Support\Product;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function () {
+    config(['seo.database.connection' => 'testing']);
+    config(['seo.database.save' => true]);
+    config(['seo.checks' => [MultipleHeadingCheck::class]]);
+
+    $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+
+    Schema::create('products', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('url')->nullable();
+    });
+
+    Http::fake([
+        'https://example.com/robots.txt' => Http::response('User-agent: *'),
+        'https://example.com/sitemap.xml' => Http::response(
+            '<?xml version="1.0"?><urlset><url><loc>https://example.com/</loc></url><url><loc>https://example.com/about</loc></url></urlset>'
+        ),
+        '*' => Http::response('<html><head><title>Test</title></head><body><h1>Test</h1></body></html>'),
+    ]);
+});
+
+afterEach(function () {
+    Schema::dropIfExists('products');
+});
+
+it('scans every discovered page of a domain and finalizes the scan', function () {
+    $scan = app(DomainScanner::class)->scan('example.com');
+
+    expect($scan->url)->toBe('https://example.com')
+        ->and($scan->pages)->toBe(2)
+        ->and($scan->finished_at)->not->toBeNull();
+
+    $urls = DB::connection('testing')->table('seo_scores')->pluck('url');
+
+    expect($urls->all())->toBe(['https://example.com/', 'https://example.com/about']);
+});
+
+it('relates the scan and its scores to the subject model', function () {
+    $product = Product::create(['url' => 'https://example.com']);
+
+    $scan = app(DomainScanner::class)->scan('example.com', subject: $product);
+
+    expect($scan->model_type)->toBe($product->getMorphClass())
+        ->and((int) $scan->model_id)->toBe($product->id);
+
+    $row = DB::connection('testing')->table('seo_scores')->first();
+
+    expect($row->model_type)->toBe($product->getMorphClass())
+        ->and((int) $row->model_id)->toBe($product->id);
+});
+
+it('dispatches the page scans as a job batch when queueing', function () {
+    Bus::fake();
+
+    $scan = app(DomainScanner::class)->scan('example.com', queue: true);
+
+    expect($scan->url)->toBe('https://example.com')
+        ->and($scan->finished_at)->toBeNull();
+
+    Bus::assertBatched(function ($batch) use ($scan) {
+        return $batch->jobs->count() === 1
+            && $batch->jobs->first() instanceof ScanChunk
+            && $batch->jobs->first()->scanId === $scan->id
+            && $batch->jobs->first()->urls === ['https://example.com/', 'https://example.com/about'];
+    });
+});
+
+it('lets queued chunk jobs inherit the subject from the scan', function () {
+    Bus::fake();
+
+    $product = Product::create(['url' => 'https://example.com']);
+
+    $scan = app(DomainScanner::class)->scan('example.com', subject: $product, queue: true);
+
+    // Run the chunk job that the batch would process.
+    (new ScanChunk(scanId: $scan->id, urls: ['https://example.com/']))
+        ->handle(app(PageScanRunner::class));
+
+    $row = DB::connection('testing')->table('seo_scores')->first();
+
+    expect($row->model_type)->toBe($product->getMorphClass())
+        ->and((int) $row->model_id)->toBe($product->id);
+});

--- a/tests/UrlDiscovererTest.php
+++ b/tests/UrlDiscovererTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use Backstage\Seo\Services\UrlDiscoverer;
+use Illuminate\Support\Facades\Http;
+
+function urlset(array $urls): string
+{
+    $locations = collect($urls)->map(fn ($url) => "<url><loc>{$url}</loc></url>")->implode('');
+
+    return '<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'.$locations.'</urlset>';
+}
+
+it('discovers urls from the sitemap listed in robots.txt', function () {
+    Http::fake([
+        'https://example.com/robots.txt' => Http::response("User-agent: *\nSitemap: https://example.com/custom-sitemap.xml"),
+        'https://example.com/custom-sitemap.xml' => Http::response(urlset([
+            'https://example.com/',
+            'https://example.com/about',
+        ])),
+    ]);
+
+    $urls = app(UrlDiscoverer::class)->discover('example.com');
+
+    expect($urls->all())->toBe([
+        'https://example.com/',
+        'https://example.com/about',
+    ]);
+});
+
+it('falls back to the sitemap.xml convention when robots.txt lists no sitemap', function () {
+    Http::fake([
+        'https://example.com/robots.txt' => Http::response('User-agent: *'),
+        'https://example.com/sitemap.xml' => Http::response(urlset(['https://example.com/contact'])),
+    ]);
+
+    $urls = app(UrlDiscoverer::class)->discover('example.com');
+
+    expect($urls->all())->toBe(['https://example.com/contact']);
+});
+
+it('follows sitemap index files', function () {
+    Http::fake([
+        'https://example.com/robots.txt' => Http::response('User-agent: *'),
+        'https://example.com/sitemap.xml' => Http::response(
+            '<?xml version="1.0"?><sitemapindex><sitemap><loc>https://example.com/pages.xml</loc></sitemap></sitemapindex>'
+        ),
+        'https://example.com/pages.xml' => Http::response(urlset(['https://example.com/pricing'])),
+    ]);
+
+    $urls = app(UrlDiscoverer::class)->discover('example.com');
+
+    expect($urls->all())->toBe(['https://example.com/pricing']);
+});
+
+it('excludes urls on other hosts and urls to assets', function () {
+    Http::fake([
+        'https://example.com/robots.txt' => Http::response('User-agent: *'),
+        'https://example.com/sitemap.xml' => Http::response(urlset([
+            'https://example.com/page',
+            'https://www.example.com/www-page',
+            'https://other.com/page',
+            'https://example.com/brochure.pdf',
+        ])),
+    ]);
+
+    $urls = app(UrlDiscoverer::class)->discover('example.com');
+
+    expect($urls->all())->toBe([
+        'https://example.com/page',
+        'https://www.example.com/www-page',
+    ]);
+});
+
+it('caps the discovered urls at the max pages limit', function () {
+    Http::fake([
+        'https://example.com/robots.txt' => Http::response('User-agent: *'),
+        'https://example.com/sitemap.xml' => Http::response(urlset(
+            collect(range(1, 10))->map(fn ($i) => "https://example.com/page-{$i}")->all()
+        )),
+    ]);
+
+    $urls = app(UrlDiscoverer::class)->discover('example.com', maxPages: 3);
+
+    expect($urls)->toHaveCount(3);
+});
+
+it('crawls same-host links when no sitemap exists', function () {
+    Http::fake([
+        'https://example.com/robots.txt' => Http::response('Not found', 404),
+        'https://example.com/sitemap.xml' => Http::response('Not found', 404),
+        'https://example.com/' => Http::response(
+            '<html><body><a href="/about">About</a><a href="https://other.com/">Other</a></body></html>',
+            headers: ['Content-Type' => 'text/html'],
+        ),
+        'https://example.com/about' => Http::response(
+            '<html><body><a href="/contact">Contact</a></body></html>',
+            headers: ['Content-Type' => 'text/html'],
+        ),
+        'https://example.com/contact' => Http::response(
+            '<html><body></body></html>',
+            headers: ['Content-Type' => 'text/html'],
+        ),
+    ]);
+
+    $urls = app(UrlDiscoverer::class)->discover('example.com');
+
+    expect($urls->all())->toBe([
+        'https://example.com/',
+        'https://example.com/about',
+        'https://example.com/contact',
+    ]);
+});
+
+it('falls back to the base url when nothing can be discovered', function () {
+    Http::fake([
+        '*' => Http::response('Not found', 404),
+    ]);
+
+    $urls = app(UrlDiscoverer::class)->discover('example.com');
+
+    expect($urls->all())->toBe(['https://example.com']);
+});
+
+it('normalizes domain input into a base url', function () {
+    $discoverer = app(UrlDiscoverer::class);
+
+    expect($discoverer->normalizeBaseUrl('example.com'))->toBe('https://example.com')
+        ->and($discoverer->normalizeBaseUrl('http://example.com/some/path'))->toBe('http://example.com')
+        ->and($discoverer->normalizeBaseUrl('https://example.com:8080/'))->toBe('https://example.com:8080');
+});
+
+it('rejects input without a valid host', function () {
+    app(UrlDiscoverer::class)->normalizeBaseUrl('https://');
+})->throws(InvalidArgumentException::class);


### PR DESCRIPTION
## Summary

Adds the ability to scan **external domains** (not just the app's own routes) via a new `seo:scan-domain` command and `Seo::scanDomain()` facade method.

- **URL discovery** (`UrlDiscoverer`): finds pages through the domain's XML sitemap(s) — via the `robots.txt` reference, the `sitemap.xml` convention, and sitemap index files — with a same-host crawl fallback when no sitemap exists. Discovery is bounded by the new `seo.crawl.max_pages` / `seo.crawl.max_depth` config options.
- **Domain scanning** (`DomainScanner`): scans every discovered page and finalizes the scan. With `--queue` the page scans are dispatched as a batched queue job and the scan finishes asynchronously.
- **Model morphing**: scans (and their scores) can be related to an application model such as a Domain or Site via `Seo::scanDomain($domain, subject: $model)`. Morph columns are string-based so integer, uuid and ulid keys are all supported (`change_model_id_to_string_on_seo_scores_table` migration; queued chunk jobs inherit the subject from the scan).
- `seo_scans` gains `url`, `model_type` and `model_id` columns (new installs get them in the base migration, existing installs via `add_url_and_model_to_seo_scans_table`).
- The database connection now respects `DB_CONNECTION` instead of hardcoding `mysql`.
- `seo:scan-domain` supports `--queue`, `--max-pages`, `--javascript` and `--format=json`.

## Test plan

- [x] `tests/UrlDiscovererTest.php` — 9 tests covering sitemap discovery (robots.txt, convention, index files), crawl fallback, host/asset filtering, max-pages cap, base-url fallback, and invalid input
- [x] `tests/DomainScannerTest.php` — 4 tests covering full-domain scan + finalize, subject morphing, queued batch dispatch, and subject inheritance in chunk jobs
- [x] All 13 new tests pass locally (24 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)